### PR TITLE
chore: add CLAUDE.md to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 .env
 data/
 TODO.md
+CLAUDE.md


### PR DESCRIPTION
Add CLAUDE.md to .gitignore to keep project-level Claude instructions out of version control