### PR TITLE
docs: add git workflow commands to README and admin plugin docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,9 +228,20 @@ The bot supports a plugin system for adding custom commands and scheduled tasks.
 ### Included Plugins
 
 **Admin Plugin** (`plugins/admin.js`)
+
+Bot management:
 - `.status` — Show bot uptime, memory usage, and PID
 - `.reload` — Hot reload all plugins without restarting the process
 - `.restart` — Full process restart (requires PM2)
+
+Git workflow (commit, PR, merge from Telegram):
+- `.git` — Show current branch and changed files
+- `.branch [name]` — Create and switch to new branch (auto-generates name if not provided)
+- `.commit [msg]` — Stage all and commit (auto-generates message if not provided)
+- `.push` — Push current branch to remote
+- `.pr [title]` — Create PR with auto-generated description
+- `.merge [squash|rebase]` — Merge PR and delete branch (defaults to squash)
+- `.ship [branch-name]` — All-in-one: branch → commit → push → PR → merge (creates branch if on main)
 
 **Quotes Plugin** (`plugins/quotes.js`)
 - `.quote` — Get an AI-generated motivational quote on demand

--- a/plugins/admin.js
+++ b/plugins/admin.js
@@ -5,10 +5,15 @@
  *   .reload  - Hot reload all plugins without restarting
  *   .restart - Full process restart (requires PM2)
  *   .status  - Show bot status and loaded plugins
+ * 
+ * Git workflow:
  *   .git     - Show git status
- *   .commit  - Stage all and commit with message
+ *   .branch  - Create and switch to new branch
+ *   .commit  - Stage all and commit (auto-generates message)
  *   .push    - Push to remote
- *   .pr      - Create pull request
+ *   .pr      - Create pull request (auto-generates description)
+ *   .merge   - Merge PR and delete branch
+ *   .ship    - All-in-one: branch → commit → push → PR → merge
  */
 
 import { exec, execSync } from "child_process";
@@ -25,6 +30,25 @@ const MAX_DIFF_CHARS = 8000; // Limit diff size for Claude prompt
 function parseArgs(msg) {
   const parts = (msg.text || "").trim().split(/\s+/);
   return parts.slice(1); // Remove the command itself
+}
+
+/**
+ * Generate a branch name from a description or timestamp
+ */
+function generateBranchName(description) {
+  if (description) {
+    // Convert description to branch-friendly format
+    return "feature/" + description
+      .toLowerCase()
+      .replace(/[^a-z0-9\s-]/g, "")
+      .trim()
+      .replace(/\s+/g, "-")
+      .slice(0, 50);
+  }
+  // Fallback to timestamp
+  const now = new Date();
+  const stamp = now.toISOString().slice(0, 10).replace(/-/g, "");
+  return `feature/update-${stamp}`;
 }
 
 export default {
@@ -112,6 +136,37 @@ export default {
         }
       } catch (e) {
         await reply(`Git error: ${e.message}`);
+      }
+    },
+
+    /**
+     * Create and switch to a new branch
+     * Usage: .branch [name]  - auto-generates name if not provided
+     */
+    async branch(msg, { reply }) {
+      const args = parseArgs(msg);
+      const name = generateBranchName(args.join(" "));
+      
+      try {
+        const currentBranch = execSync("git branch --show-current", GIT_CWD).trim();
+        
+        // Already on a feature branch?
+        if (!["main", "master"].includes(currentBranch)) {
+          await reply(`Already on branch: ${currentBranch}`);
+          return;
+        }
+        
+        // Create and switch to new branch
+        execSync(`git checkout -b ${name}`, GIT_CWD);
+        await reply(`Created branch: ${name}`);
+      } catch (e) {
+        if (e.message.includes("already exists")) {
+          // Branch exists, just switch to it
+          execSync(`git checkout ${name}`, GIT_CWD);
+          await reply(`Switched to existing branch: ${name}`);
+        } else {
+          await reply(`Branch error: ${e.message}`);
+        }
       }
     },
 
@@ -280,6 +335,241 @@ BODY:
         } else {
           await reply(`PR failed: ${e.message}`);
         }
+      }
+    },
+
+    /**
+     * Merge current PR and clean up branch
+     * Usage: .merge [squash|rebase]  - defaults to squash
+     */
+    async merge(msg, { reply }) {
+      const args = parseArgs(msg);
+      const strategy = args[0]?.toLowerCase() || "squash";
+      
+      if (!["squash", "merge", "rebase"].includes(strategy)) {
+        await reply("Usage: .merge [squash|merge|rebase]");
+        return;
+      }
+      
+      try {
+        // Get current branch before merging
+        const currentBranch = execSync("git branch --show-current", GIT_CWD).trim();
+        
+        // Check if we're on main/master
+        if (["main", "master"].includes(currentBranch)) {
+          await reply("Already on main branch - nothing to merge");
+          return;
+        }
+        
+        // Get base branch
+        let baseBranch = "main";
+        try {
+          execSync("git rev-parse --verify main", GIT_CWD);
+        } catch {
+          baseBranch = "master";
+        }
+        
+        await reply(`Merging PR (${strategy})...`);
+        
+        // Merge the PR and delete the remote branch
+        execSync(`gh pr merge --${strategy} --delete-branch`, GIT_CWD);
+        
+        // Switch to base branch and pull
+        execSync(`git checkout ${baseBranch}`, GIT_CWD);
+        execSync("git pull", GIT_CWD);
+        
+        // Delete local branch
+        try {
+          execSync(`git branch -d ${currentBranch}`, GIT_CWD);
+        } catch {
+          // Branch might already be deleted or have unmerged changes
+          execSync(`git branch -D ${currentBranch}`, GIT_CWD);
+        }
+        
+        await reply(`Merged and deleted branch: ${currentBranch}\nNow on: ${baseBranch}`);
+      } catch (e) {
+        await reply(`Merge failed: ${e.message}`);
+      }
+    },
+
+    /**
+     * Ship it! Commit, push, create PR, merge - all in one
+     * Auto-creates a branch if on main/master
+     * Usage: .ship [branch-name]
+     */
+    async ship(msg, { reply }) {
+      try {
+        const args = parseArgs(msg);
+        
+        // Get current branch
+        let currentBranch = execSync("git branch --show-current", GIT_CWD).trim();
+        
+        // Get base branch
+        let baseBranch = "main";
+        try {
+          execSync("git rev-parse --verify main", GIT_CWD);
+        } catch {
+          baseBranch = "master";
+        }
+        
+        // If on main/master, create a feature branch first
+        if (["main", "master"].includes(currentBranch)) {
+          // Check if there are changes to ship
+          execSync("git add -A", GIT_CWD);
+          const status = execSync("git status --porcelain", GIT_CWD).trim();
+          
+          if (!status) {
+            await reply("Nothing to ship - no changes detected");
+            return;
+          }
+          
+          // Generate branch name from args or diff
+          let branchName = args.join(" ");
+          if (!branchName) {
+            // Try to generate from staged diff
+            let diff = execSync("git diff --staged --stat", GIT_CWD).trim();
+            // Extract first changed file name as hint
+            const firstFile = diff.split("\n")[0]?.split("|")[0]?.trim();
+            if (firstFile) {
+              branchName = firstFile.replace(/\.[^.]+$/, "").replace(/[/\\]/g, "-");
+            }
+          }
+          
+          currentBranch = generateBranchName(branchName);
+          await reply(`🌿 Creating branch: ${currentBranch}`);
+          execSync(`git checkout -b ${currentBranch}`, GIT_CWD);
+        }
+        
+        // Step 1: Stage and check for changes
+        execSync("git add -A", GIT_CWD);
+        const status = execSync("git status --porcelain", GIT_CWD).trim();
+        
+        let hasNewCommit = false;
+        if (status) {
+          // Step 2: Generate commit message and commit
+          await reply("📦 Generating commit message...");
+          
+          let diff = execSync("git diff --staged", GIT_CWD);
+          if (diff.length > MAX_DIFF_CHARS) {
+            diff = diff.slice(0, MAX_DIFF_CHARS) + "\n... (truncated)";
+          }
+          
+          let commitMsg = "Update from Telegram";
+          try {
+            const prompt = `Generate a concise git commit message (1 line, max 72 chars) for these changes. Follow conventional commits style (feat:, fix:, chore:, etc). Reply with ONLY the commit message, nothing else.\n\n${diff}`;
+            const result = await runClaude(prompt);
+            commitMsg = result.result?.trim().replace(/^["'\`]+|["'\`]+$/g, "").trim() || commitMsg;
+          } catch (e) {
+            console.error("[admin] Failed to generate commit message:", e.message);
+          }
+          
+          execSync(`git commit -m "${commitMsg.replace(/"/g, '\\"')}"`, GIT_CWD);
+          await reply(`✓ Committed: ${commitMsg}`);
+          hasNewCommit = true;
+        } else {
+          await reply("📦 No new changes to commit");
+        }
+        
+        // Step 3: Push
+        await reply("🚀 Pushing to remote...");
+        execSync("git push -u origin HEAD", GIT_CWD);
+        await reply("✓ Pushed");
+        
+        // Step 4: Check if PR already exists
+        let prUrl = "";
+        try {
+          prUrl = execSync("gh pr view --json url -q .url", GIT_CWD).trim();
+        } catch {
+          // No PR exists yet
+        }
+        
+        if (!prUrl) {
+          // Step 5: Create PR with generated description
+          await reply("📝 Generating PR description...");
+          
+          let diff = "";
+          let commits = "";
+          try {
+            diff = execSync(`git diff ${baseBranch}...HEAD`, GIT_CWD);
+            if (diff.length > MAX_DIFF_CHARS) {
+              diff = diff.slice(0, MAX_DIFF_CHARS) + "\n... (truncated)";
+            }
+            commits = execSync(`git log ${baseBranch}..HEAD --oneline`, GIT_CWD);
+          } catch {
+            diff = execSync("git diff HEAD~1", GIT_CWD);
+            commits = execSync("git log -3 --oneline", GIT_CWD);
+          }
+          
+          let title = currentBranch.replace(/[-_]/g, " ").replace(/^(feature|fix|chore)\//, "");
+          let body = "";
+          
+          try {
+            const prompt = `Generate a GitHub pull request title and description for these changes.
+
+Branch: ${currentBranch}
+Commits:
+${commits}
+
+Diff:
+${diff}
+
+Reply in this exact format (no other text):
+TITLE: <concise title, max 72 chars>
+BODY:
+<markdown description with:
+- Summary (1-2 sentences)
+- Key changes (bullet points)
+- Any notes for reviewers>`;
+
+            const result = await runClaude(prompt);
+            const response = result.result?.trim() || "";
+            
+            const titleMatch = response.match(/TITLE:\s*(.+)/);
+            const bodyMatch = response.match(/BODY:\s*([\s\S]+)/);
+            
+            if (titleMatch) title = titleMatch[1].trim();
+            if (bodyMatch) body = bodyMatch[1].trim();
+          } catch (e) {
+            console.error("[admin] Failed to generate PR description:", e.message);
+          }
+          
+          let cmd = `gh pr create --title "${title.replace(/"/g, '\\"')}"`;
+          if (body) {
+            const { writeFileSync } = await import("fs");
+            const bodyFile = "/tmp/pr-body.md";
+            writeFileSync(bodyFile, body);
+            cmd += ` --body-file "${bodyFile}"`;
+          } else {
+            cmd += " --fill";
+          }
+          
+          prUrl = execSync(cmd, GIT_CWD).trim();
+          await reply(`✓ PR created: ${prUrl}`);
+        } else {
+          await reply(`✓ PR exists: ${prUrl}`);
+        }
+        
+        // Step 6: Merge
+        await reply("🔀 Merging PR...");
+        execSync("gh pr merge --squash --delete-branch", GIT_CWD);
+        
+        // Step 7: Cleanup
+        execSync(`git checkout ${baseBranch}`, GIT_CWD);
+        execSync("git pull", GIT_CWD);
+        
+        try {
+          execSync(`git branch -d ${currentBranch}`, GIT_CWD);
+        } catch {
+          try {
+            execSync(`git branch -D ${currentBranch}`, GIT_CWD);
+          } catch {
+            // Branch already deleted
+          }
+        }
+        
+        await reply(`🎉 Shipped! Merged ${currentBranch} → ${baseBranch}`);
+      } catch (e) {
+        await reply(`Ship failed: ${e.message}`);
       }
     },
   },


### PR DESCRIPTION
## Summary
Document the new git workflow commands (`.branch`, `.commit`, `.push`, `.pr`, `.merge`, `.ship`) in the README and update the admin plugin's JSDoc header to reflect all available commands.

## Key changes
- Added "Git workflow" section to the Admin Plugin docs in README with descriptions for `.git`, `.branch`, `.commit`, `.push`, `.pr`, `.merge`, and `.ship`
- Updated admin plugin JSDoc comment block to include `.branch`, `.merge`, and `.ship` commands
- Added `generateBranchName()` helper for auto-generating branch names
- Implemented `.branch` command for creating/switching feature branches
- Implemented `.merge` command with squash/merge/rebase strategies and branch cleanup
- Implemented `.ship` command as an all-in-one workflow (branch, commit, push, PR, merge)

## Notes for reviewers
- The `.ship` command uses `git add -A` which stages all files — worth confirming this is acceptable given the bot's deployment context
- Branch names passed to `execSync` are derived from user input via `generateBranchName()` which strips special characters, but reviewers may want to verify the sanitization is sufficient