### PR TITLE
feat: add plugin destroy lifecycle and .stop command

### DIFF
--- a/plugins/admin.js
+++ b/plugins/admin.js
@@ -3,6 +3,7 @@
  * 
  * Provides administrative commands for managing the bot:
  *   .reload  - Hot reload all plugins without restarting
+ *   .stop    - Emergency stop (kills the process immediately)
  *   .restart - Full process restart (requires PM2)
  *   .status  - Show bot status and loaded plugins
  * 
@@ -77,6 +78,15 @@ export default {
       } catch (err) {
         await reply(`Reload failed: ${err.message}`);
       }
+    },
+
+    /**
+     * Emergency stop — immediately kills the process
+     * Usage: .stop
+     */
+    async stop(msg, { reply }) {
+      await reply("Stopping bot...");
+      process.exit(0);
     },
 
     /**

--- a/src/plugin-loader.js
+++ b/src/plugin-loader.js
@@ -29,6 +29,8 @@ const commandHandlers = new Map();
 const messageHandlers = [];
 // Track scheduled tasks so we can stop them on reload
 const scheduledTasks = [];
+// Track plugin destroy functions for cleanup on reload
+const destroyHandlers = [];
 
 // Store references for use in handlers
 let _runClaude, _config, _channels;
@@ -131,6 +133,15 @@ export async function loadPlugins({ channels, config, runClaude }) {
           handler: plugin.onMessage,
         });
         console.log(`[plugins]   Registered message handler`);
+      }
+
+      // Register destroy handler for cleanup on reload
+      if (plugin.destroy) {
+        destroyHandlers.push({
+          name: plugin.name,
+          handler: plugin.destroy,
+        });
+        console.log(`[plugins]   Registered destroy handler`);
       }
 
       // Call init if provided (runs once at startup)
@@ -246,6 +257,17 @@ export async function reloadPlugins() {
   
   const errors = [];
   
+  // Call destroy handlers for plugin cleanup (timers, connections, etc.)
+  for (const { name, handler } of destroyHandlers) {
+    try {
+      await handler();
+      console.log(`[plugins] Destroyed: ${name}`);
+    } catch (err) {
+      console.error(`[plugins] Destroy error (${name}):`, err.message);
+    }
+  }
+  destroyHandlers.length = 0;
+
   // Stop all scheduled tasks
   for (const task of scheduledTasks) {
     try {
@@ -255,7 +277,7 @@ export async function reloadPlugins() {
     }
   }
   scheduledTasks.length = 0;
-  
+
   // Clear existing handlers
   commandHandlers.clear();
   messageHandlers.length = 0;
@@ -321,6 +343,15 @@ export async function reloadPlugins() {
           handler: plugin.onMessage,
         });
         console.log(`[plugins]   Registered message handler`);
+      }
+
+      // Register destroy handler for cleanup on reload
+      if (plugin.destroy) {
+        destroyHandlers.push({
+          name: plugin.name,
+          handler: plugin.destroy,
+        });
+        console.log(`[plugins]   Registered destroy handler`);
       }
 
       // Call init if provided


### PR DESCRIPTION
## Summary
Adds a `destroy` lifecycle hook for plugins to clean up resources (timers, connections, etc.) during hot reload, and introduces a `.stop` admin command for emergency process shutdown.

## Key changes
- Add `destroyHandlers` registry in plugin-loader to track plugin cleanup functions
- Call registered `destroy` handlers before clearing state during `.reload`
- Re-register `destroy` handlers after plugins are reloaded
- Add `.stop` admin command that calls `process.exit(0)` for immediate shutdown
- Update admin plugin docs to list `.stop` command

## Notes for reviewers
- The `destroy` lifecycle runs **before** scheduled tasks are stopped during reload, giving plugins a chance to tear down their own resources first.
- `.stop` is intentionally a hard exit (`process.exit(0)`) rather than a graceful shutdown — it's meant as an emergency kill switch.