### PR TITLE
fix: reply with helpful message for unknown dot commands

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -60,7 +60,8 @@ async function handleMessage(msg, channels) {
   if (msg.text.startsWith(".")) {
     const pluginHandled = await handlePluginMessage(msg);
     if (pluginHandled) return;
-    // Unknown .command - ignore silently
+    const cmdName = msg.text.slice(1).split(/\s+/)[0];
+    await channel.send(msg.channelId, `Unknown command: .${cmdName}\nTry .reload if you recently added a plugin.`);
     return;
   }
 


### PR DESCRIPTION
## Summary
Instead of silently ignoring unrecognized dot commands, the bot now replies with a helpful message indicating the command is unknown and suggesting `.reload` if a plugin was recently added.

## Key changes
- Replaced silent ignore for unknown `.commands` with a user-facing message that names the unrecognized command
- Suggests `.reload` as a recovery action for newly added plugins

## Notes for reviewers
- The feedback message is intentionally concise; could be extended later with a list of available commands if desired