### PR TITLE
Add .changes command and deduplicate quotes with history log

### DIFF
--- a/plugins/admin.js
+++ b/plugins/admin.js
@@ -6,7 +6,10 @@
  *   .stop    - Emergency stop (kills the process immediately)
  *   .restart - Full process restart (requires PM2)
  *   .status  - Show bot status and loaded plugins
- * 
+ *
+ * Git:
+ *   .changes - Summarize uncommitted changes using Claude
+ *
  * Git workflow:
  *   .git     - Show git status
  *   .branch  - Create and switch to new branch
@@ -128,6 +131,38 @@ export default {
         `• Node: ${process.version}\n` +
         `• PID: ${process.pid}`
       );
+    },
+
+    /**
+     * Summarize uncommitted changes using Claude
+     * Usage: .changes
+     */
+    async changes(msg, { reply, sendTyping, claude }) {
+      try {
+        const status = execSync("git status --short", GIT_CWD).trim();
+        if (!status) {
+          await reply("No uncommitted changes.");
+          return;
+        }
+
+        await sendTyping();
+
+        let diff = execSync("git diff", GIT_CWD) + execSync("git diff --staged", GIT_CWD);
+        if (diff.length > MAX_DIFF_CHARS) {
+          diff = diff.slice(0, MAX_DIFF_CHARS) + "\n... (truncated)";
+        }
+
+        const branch = execSync("git branch --show-current", GIT_CWD).trim();
+
+        const result = await claude(
+          `Summarize these uncommitted git changes in a concise, readable way. Group by theme (e.g. new features, bug fixes, refactors). Use bullet points. Keep it short — this is for a quick Telegram status update.\n\nBranch: ${branch}\n\nFiles changed:\n${status}\n\nDiff:\n${diff}`
+        );
+
+        const summary = result.result?.trim() || "Could not generate summary.";
+        await reply(`📝 Changes on ${branch}:\n\n${summary}`);
+      } catch (err) {
+        await reply(`Error: ${err.message.slice(0, 200)}`);
+      }
     },
 
     /**

--- a/plugins/local
+++ b/plugins/local
@@ -1,0 +1,1 @@
+/Users/tim/Claude/local-oyster-bot-plugins

--- a/plugins/quotes.js
+++ b/plugins/quotes.js
@@ -1,15 +1,63 @@
 /**
  * Quotes Plugin
- * 
- * Sends positive, uplifting quotes using Claude.
+ *
+ * Sends real, inspiring quotes using Claude.
  * - .quote command: get a quote on demand
  * - Scheduled: sends a quote at the configured interval (default: hourly)
+ *
+ * Tracks past quotes in data/quotes-log.json to avoid duplicates.
  */
 
-const QUOTE_PROMPT = `Generate a single short, uplifting, and motivational quote. 
-Be creative and original - don't use famous quotes. 
-Keep it under 280 characters. 
-Just output the quote itself, nothing else - no quotation marks, no attribution, no preamble.`;
+import { readFileSync, writeFileSync, existsSync, mkdirSync } from "fs";
+import { join, dirname } from "path";
+import { fileURLToPath } from "url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const DATA_DIR = join(__dirname, "..", "data");
+const QUOTES_FILE = join(DATA_DIR, "quotes-log.json");
+
+function loadPastQuotes() {
+  try {
+    if (existsSync(QUOTES_FILE)) {
+      return JSON.parse(readFileSync(QUOTES_FILE, "utf-8"));
+    }
+  } catch (err) {
+    console.error("[quotes] Error loading quotes log:", err.message);
+  }
+  return [];
+}
+
+function saveQuote(quote) {
+  if (!existsSync(DATA_DIR)) {
+    mkdirSync(DATA_DIR, { recursive: true });
+  }
+  const log = loadPastQuotes();
+  log.push({ quote, date: new Date().toISOString() });
+  writeFileSync(QUOTES_FILE, JSON.stringify(log, null, 2));
+}
+
+function buildPrompt() {
+  const past = loadPastQuotes();
+  let avoidClause = "";
+  if (past.length > 0) {
+    // Send the last 50 to keep prompt size reasonable
+    const recent = past.slice(-50).map((q) => q.quote).join("\n");
+    avoidClause = `\n\nDo NOT repeat any of these previously sent quotes:\n${recent}`;
+  }
+
+  return `Share a real, inspiring quote from a real person (entrepreneur, scientist, author, philosopher, athlete, etc.). It must be a genuine quote that the person actually said or wrote — not made up. Include the attribution.
+
+Format: "<quote>" — <Person Name>
+
+Keep it under 280 characters total. Output only the formatted quote, nothing else.${avoidClause}`;
+}
+
+async function getQuote(claude) {
+  const result = await claude(buildPrompt());
+  const quote = result.result || result.content || "Stay positive!";
+  saveQuote(quote);
+  return quote;
+}
 
 export default {
   name: "quotes",
@@ -17,10 +65,7 @@ export default {
   commands: {
     quote: async (msg, { sendTyping, reply, claude }) => {
       await sendTyping();
-      
-      const result = await claude(QUOTE_PROMPT);
-      const quote = result.result || result.content || "Stay positive!";
-      
+      const quote = await getQuote(claude);
       await reply(`✨ ${quote}`);
     },
   },
@@ -29,11 +74,11 @@ export default {
     {
       // Default: every hour on the hour. Override with QUOTES_CRON env var.
       cron: process.env.QUOTES_CRON || "0 * * * *",
-      
+
       handler: async ({ channels, config, claude }) => {
         const targetChatId = config.plugins?.targetChatId;
         const targetChannel = config.plugins?.targetChannel || "telegram";
-        
+
         if (!targetChatId) {
           console.log("[quotes] No PLUGIN_TARGET_CHAT_ID configured, skipping scheduled quote");
           return;
@@ -46,9 +91,7 @@ export default {
         }
 
         try {
-          const result = await claude(QUOTE_PROMPT);
-          const quote = result.result || result.content || "Stay positive!";
-          
+          const quote = await getQuote(claude);
           await channel.send(String(targetChatId), `✨ ${quote}`);
           console.log("[quotes] Sent scheduled quote");
         } catch (err) {


### PR DESCRIPTION
## Summary
Adds a `.changes` command that summarizes uncommitted git changes using Claude, and improves the quotes plugin to track past quotes and avoid sending duplicates.

## Key changes
- **`.changes` command** (admin plugin): Runs `git diff`, sends it to Claude, and replies with a concise summary of uncommitted changes — useful for quick Telegram status updates
- **Quotes deduplication**: Tracks all sent quotes in `data/quotes-log.json` and includes recent history in the prompt so Claude avoids repeating them
- **Real quotes**: Switches from AI-generated original quotes to real, attributed quotes from real people
- Adds a `plugins/local` symlink for local plugin development

## Notes for reviewers
- The `plugins/local` symlink points to an absolute path (`/Users/tim/Claude/local-oyster-bot-plugins`) — this may need to be gitignored or removed before merge if it's only for local dev
- The quotes log file (`data/quotes-log.json`) will grow unbounded over time; only the last 50 entries are used in the prompt, but older entries are retained in the file