### PR TITLE
feat: add help plugin with per-command descriptions

### DIFF
--- a/plugins/admin.js
+++ b/plugins/admin.js
@@ -58,6 +58,21 @@ function generateBranchName(description) {
 export default {
   name: "admin",
 
+  help: {
+    reload: "Hot reload all plugins",
+    stop: "Emergency stop the bot",
+    restart: "Full process restart via PM2",
+    status: "Show bot status and uptime",
+    changes: "Summarize uncommitted git changes",
+    git: "Show git status",
+    branch: "Create and switch to a new branch",
+    commit: "Stage all and commit (auto-generates message)",
+    push: "Push to remote",
+    pr: "Create a pull request",
+    merge: "Merge current PR and clean up",
+    ship: "All-in-one: branch, commit, push, PR, merge",
+  },
+
   commands: {
     /**
      * Hot reload all plugins

--- a/plugins/food-diary.js
+++ b/plugins/food-diary.js
@@ -82,6 +82,11 @@ function formatDate(isoString) {
 export default {
   name: "food-diary",
 
+  help: {
+    food: "Log what you ate",
+    foodlog: "View recent food entries",
+  },
+
   commands: {
     food: async (msg, { reply }) => {
       const userKey = getUserKey(msg);

--- a/plugins/gratitude.js
+++ b/plugins/gratitude.js
@@ -57,6 +57,11 @@ function addEntry(userId, channelType, text) {
 export default {
   name: "gratitude",
 
+  help: {
+    thanks: "Log something you're grateful for",
+    grateful: "View your gratitude log",
+  },
+
   commands: {
     thanks: async (msg, { reply }) => {
       const userKey = getUserKey(msg);

--- a/plugins/help.js
+++ b/plugins/help.js
@@ -1,0 +1,38 @@
+/**
+ * Help Plugin
+ *
+ * Shows all available plugin commands.
+ * - .help — List all commands grouped by plugin
+ */
+
+export default {
+  name: "help",
+
+  help: {
+    help: "Show all available commands",
+  },
+
+  commands: {
+    help: async (msg, { reply, getRegisteredCommands }) => {
+      const commands = getRegisteredCommands();
+
+      // Group by plugin name
+      const grouped = {};
+      for (const { command, pluginName, description } of commands) {
+        if (!grouped[pluginName]) grouped[pluginName] = [];
+        grouped[pluginName].push({ command, description });
+      }
+
+      const lines = [];
+      for (const [plugin, cmds] of Object.entries(grouped)) {
+        lines.push(`${plugin}`);
+        for (const { command, description } of cmds) {
+          lines.push(description ? `  .${command} — ${description}` : `  .${command}`);
+        }
+        lines.push("");
+      }
+
+      await reply(lines.join("\n").trimEnd());
+    },
+  },
+};

--- a/plugins/quotes.js
+++ b/plugins/quotes.js
@@ -62,6 +62,10 @@ async function getQuote(claude) {
 export default {
   name: "quotes",
 
+  help: {
+    quote: "Get an inspiring quote",
+  },
+
   commands: {
     quote: async (msg, { sendTyping, reply, claude }) => {
       await sendTyping();

--- a/plugins/reminder.js
+++ b/plugins/reminder.js
@@ -371,6 +371,15 @@ function restoreReminders() {
 export default {
   name: "reminder",
 
+  help: {
+    reminder: "Set a reminder (e.g., .reminder call mom 30m)",
+    reminders: "View pending reminders",
+    cancelreminder: "Cancel a reminder by ID",
+    every: "Set a daily recurring reminder (e.g., .every 10pm stretch)",
+    recurring: "View active recurring reminders",
+    reminderlog: "View completed reminder history",
+  },
+
   commands: {
     reminder: async (msg, { reply, channels }) => {
       // Store channels reference if not already set

--- a/plugins/todo.js
+++ b/plugins/todo.js
@@ -58,6 +58,12 @@ function addTodo(userId, channelType, text) {
 export default {
   name: "todo",
 
+  help: {
+    todo: "Add a todo item",
+    todos: "View your todo list",
+    done: "Mark a todo as done (e.g., .done 1)",
+  },
+
   commands: {
     todo: async (msg, { reply }) => {
       const userKey = getUserKey(msg);

--- a/plugins/weather.js
+++ b/plugins/weather.js
@@ -53,6 +53,10 @@ async function fetchWeather(location, { sendTyping, reply, claude }) {
 export default {
   name: "weather",
 
+  help: {
+    weather: "Get current weather for a location",
+  },
+
   commands: {
     weather: async (msg, helpers) => {
       const { reply, channel, config } = helpers;

--- a/src/plugin-loader.js
+++ b/src/plugin-loader.js
@@ -23,7 +23,7 @@ const LOCAL_PLUGINS_DIR = join(PLUGINS_DIR, "local");
  * The `reply` helper sends a response back through the appropriate channel.
  */
 
-// Collected command handlers from plugins: commandName -> { handler, pluginName }
+// Collected command handlers from plugins: commandName -> { handler, pluginName, description }
 const commandHandlers = new Map();
 // Collected message handlers from plugins
 const messageHandlers = [];
@@ -92,10 +92,12 @@ export async function loadPlugins({ channels, config, runClaude }) {
 
       // Register commands (will be triggered by .commandName)
       if (plugin.commands) {
+        const helpMap = plugin.help || {};
         for (const [cmdName, handler] of Object.entries(plugin.commands)) {
           commandHandlers.set(cmdName.toLowerCase(), {
             handler,
             pluginName: plugin.name,
+            description: helpMap[cmdName] || null,
           });
           console.log(`[plugins]   Registered command: .${cmdName}`);
         }
@@ -214,6 +216,7 @@ export async function handlePluginMessage(msg) {
     config: _config,
     channel,
     channels: _channels,
+    getRegisteredCommands,
   };
   
   // Handle .commands
@@ -302,10 +305,12 @@ export async function reloadPlugins() {
 
       // Register commands
       if (plugin.commands) {
+        const helpMap = plugin.help || {};
         for (const [cmdName, handler] of Object.entries(plugin.commands)) {
           commandHandlers.set(cmdName.toLowerCase(), {
             handler,
             pluginName: plugin.name,
+            description: helpMap[cmdName] || null,
           });
           console.log(`[plugins]   Registered command: .${cmdName}`);
         }
@@ -322,10 +327,10 @@ export async function reloadPlugins() {
           const task = cron.schedule(schedule.cron, async () => {
             console.log(`[plugins] Running scheduled task for: ${plugin.name}`);
             try {
-              await schedule.handler({ 
-                channels: _channels, 
-                config: _config, 
-                claude: _runClaude 
+              await schedule.handler({
+                channels: _channels,
+                config: _config,
+                claude: _runClaude
               });
             } catch (err) {
               console.error(`[plugins] Scheduled task error (${plugin.name}):`, err.message);
@@ -384,4 +389,16 @@ export async function reloadPlugins() {
   };
 }
 
-export default { loadPlugins, handlePluginMessage, reloadPlugins };
+/**
+ * Get all registered commands with their plugin names and descriptions
+ * @returns {Array<{ command: string, pluginName: string, description: string|null }>}
+ */
+export function getRegisteredCommands() {
+  const commands = [];
+  for (const [command, { pluginName, description }] of commandHandlers) {
+    commands.push({ command, pluginName, description });
+  }
+  return commands;
+}
+
+export default { loadPlugins, handlePluginMessage, reloadPlugins, getRegisteredCommands };


### PR DESCRIPTION
## Summary

Adds a `.help` command that lists all available bot commands grouped by plugin, along with short descriptions for each command.

## Key changes

- Add new `help` plugin with `.help` command that outputs all registered commands grouped by plugin name
- Add `help` metadata objects to all existing plugins (admin, food-diary, gratitude, quotes, reminder, todo, weather) with per-command descriptions
- Extend plugin loader to store and expose command descriptions via a new `getRegisteredCommands()` function
- Pass `getRegisteredCommands` helper to command handlers so the help plugin can query available commands at runtime

## Notes for reviewers

- The `help` map on each plugin is optional — commands without a description entry still appear in `.help` output, just without a description
- No changes to existing command behavior; this is purely additive