### PR TITLE
fix: prevent duplicate recurring reminder timeouts

### DIFF
--- a/plugins/reminder.js
+++ b/plugins/reminder.js
@@ -201,6 +201,11 @@ async function sendRecurringReminder(recurring) {
  * Schedule a recurring reminder for its next occurrence
  */
 function scheduleRecurring(recurring) {
+  // Clear any existing timeout to prevent duplicates
+  if (activeTimeouts.has(recurring.id)) {
+    clearTimeout(activeTimeouts.get(recurring.id));
+  }
+
   const next = getNextOccurrence(recurring.hour, recurring.minute);
   const delay = next.getTime() - Date.now();
 


### PR DESCRIPTION
## Summary
Fixes a bug where recurring reminders could accumulate multiple active timeouts, causing duplicate reminder messages to be sent.

## Key changes
- Clear any existing timeout for a recurring reminder before scheduling a new one
- Uses the existing `activeTimeouts` map to track and clean up previous timeouts

## Notes for reviewers
This is a defensive fix that ensures `scheduleRecurring()` is idempotent. If called multiple times for the same reminder (e.g., during restarts or re-scheduling), it now properly cleans up the previous timeout instead of leaving orphaned timers running.