### PR TITLE
feat: add plugin destroy lifecycle for graceful shutdown cleanup

### DIFF
--- a/plugins/admin.js
+++ b/plugins/admin.js
@@ -21,7 +21,7 @@
  */
 
 import { exec, execSync } from "child_process";
-import { reloadPlugins } from "../src/plugin-loader.js";
+import { reloadPlugins, destroyPlugins } from "../src/plugin-loader.js";
 import { runClaude } from "../src/claude.js";
 
 const GIT_CWD = { cwd: process.cwd(), encoding: "utf8" };
@@ -104,6 +104,7 @@ export default {
      */
     async stop(msg, { reply }) {
       await reply("Stopping bot...");
+      await destroyPlugins();
       process.exit(0);
     },
 

--- a/plugins/reminder.js
+++ b/plugins/reminder.js
@@ -612,4 +612,13 @@ export default {
     restoreReminders();
     restoreRecurring();
   },
+
+  // Clean up all active timeouts on shutdown/reload
+  destroy: () => {
+    for (const timeoutId of activeTimeouts.values()) {
+      clearTimeout(timeoutId);
+    }
+    activeTimeouts.clear();
+    console.log("[reminder] Cleared all active timeouts");
+  },
 };

--- a/src/app.js
+++ b/src/app.js
@@ -8,7 +8,7 @@
 import config from "./config.js";
 import { runClaude } from "./claude.js";
 import { createChannels } from "./channels/index.js";
-import { loadPlugins, handlePluginMessage } from "./plugin-loader.js";
+import { loadPlugins, handlePluginMessage, destroyPlugins } from "./plugin-loader.js";
 import { getSessionKey } from "./types/message.js";
 
 // Per-session tracking: sessionKey -> Claude sessionId
@@ -194,6 +194,7 @@ async function start() {
   // Graceful shutdown
   const shutdown = async (signal) => {
     console.log(`\n[app] Received ${signal}, shutting down...`);
+    await destroyPlugins();
     for (const [type, channel] of channels) {
       await channel.stop();
       console.log(`[app] Stopped channel: ${type}`);

--- a/src/plugin-loader.js
+++ b/src/plugin-loader.js
@@ -401,4 +401,26 @@ export function getRegisteredCommands() {
   return commands;
 }
 
-export default { loadPlugins, handlePluginMessage, reloadPlugins, getRegisteredCommands };
+/**
+ * Run all plugin destroy handlers and stop scheduled tasks.
+ * Called during graceful shutdown to clean up timers, connections, etc.
+ */
+export async function destroyPlugins() {
+  for (const { name, handler } of destroyHandlers) {
+    try {
+      await handler();
+      console.log(`[plugins] Destroyed: ${name}`);
+    } catch (err) {
+      console.error(`[plugins] Destroy error (${name}):`, err.message);
+    }
+  }
+  for (const task of scheduledTasks) {
+    try {
+      task.stop();
+    } catch (err) {
+      // Ignore stop errors
+    }
+  }
+}
+
+export default { loadPlugins, handlePluginMessage, reloadPlugins, getRegisteredCommands, destroyPlugins };


### PR DESCRIPTION
## Summary
Adds a `destroy` lifecycle hook for plugins, ensuring timers and resources are cleaned up during graceful shutdown or bot stop.

## Key changes
- Add `destroyPlugins()` to `plugin-loader.js` that runs all registered destroy handlers and stops scheduled tasks
- Add `destroy` hook to the reminder plugin to clear active timeouts on shutdown
- Call `destroyPlugins()` in the app's SIGINT/SIGTERM handler and the admin `.stop` command

## Notes for reviewers
- Destroy handlers are called with `await`, so async cleanup is supported
- Errors in individual destroy handlers are caught and logged without blocking other plugins from cleaning up