### PR TITLE
notifications plugin

### DIFF
--- a/plugins/notifications.js
+++ b/plugins/notifications.js
@@ -1,0 +1,90 @@
+/**
+ * Notifications Plugin
+ *
+ * Lists all active scheduled messages and their times across all plugins.
+ * - .notifications — View all active notifications (reminders, recurring, cron schedules)
+ */
+
+function formatDuration(ms) {
+  const seconds = Math.floor(ms / 1000);
+  const minutes = Math.floor(seconds / 60);
+  const hours = Math.floor(minutes / 60);
+  const days = Math.floor(hours / 24);
+
+  if (days > 0) return `${days}d ${hours % 24}h`;
+  if (hours > 0) return `${hours}h ${minutes % 60}m`;
+  if (minutes > 0) return `${minutes}m`;
+  return `${seconds}s`;
+}
+
+function formatClockTime(hour, minute) {
+  const period = hour >= 12 ? "pm" : "am";
+  const displayHour = hour === 0 ? 12 : hour > 12 ? hour - 12 : hour;
+  return minute === 0
+    ? `${displayHour}${period}`
+    : `${displayHour}:${String(minute).padStart(2, "0")}${period}`;
+}
+
+export default {
+  name: "notifications",
+
+  help: {
+    notifications: "View all active scheduled notifications",
+  },
+
+  commands: {
+    notifications: async (msg, { reply, getRegisteredSchedules, getRegisteredNotifications }) => {
+      const sections = [];
+
+      // Notifications from the registry (reminders, recurring, and any plugin-registered notifications)
+      const notifications = typeof getRegisteredNotifications === "function" ? getRegisteredNotifications() : [];
+
+      const reminders = notifications.filter(n => n.type === "reminder");
+      if (reminders.length > 0) {
+        const lines = reminders.map((r, i) => {
+          const timeLeft = new Date(r.nextAt).getTime() - Date.now();
+          const status = timeLeft > 0 ? `in ${formatDuration(timeLeft)}` : "sending soon";
+          return `  ${i + 1}. "${r.label}" — ${status}`;
+        });
+        sections.push(`⏰ Reminders\n${lines.join("\n")}`);
+      }
+
+      const recurring = notifications.filter(n => n.type === "recurring");
+      if (recurring.length > 0) {
+        const lines = recurring.map((r, i) => {
+          const timeLeft = new Date(r.nextAt).getTime() - Date.now();
+          const timeStr = r.meta ? `daily at ${formatClockTime(r.meta.hour, r.meta.minute)}` : "";
+          return `  ${i + 1}. "${r.label}" — ${timeStr} (next in ${formatDuration(timeLeft)})`;
+        });
+        sections.push(`🔁 Recurring\n${lines.join("\n")}`);
+      }
+
+      // Other plugin notifications (not reminder/recurring)
+      const other = notifications.filter(n => n.type !== "reminder" && n.type !== "recurring");
+      if (other.length > 0) {
+        const lines = other.map((n, i) => {
+          const timeInfo = n.nextAt ? ` — next in ${formatDuration(new Date(n.nextAt).getTime() - Date.now())}` : "";
+          return `  ${i + 1}. [${n.pluginName}] ${n.label}${timeInfo}`;
+        });
+        sections.push(`🔔 Other\n${lines.join("\n")}`);
+      }
+
+      // Cron schedules (system-wide)
+      const schedules = getRegisteredSchedules();
+      if (schedules.length > 0) {
+        const lines = schedules.map((s, i) => {
+          const label = s.label || s.pluginName;
+          return `  ${i + 1}. ${label} — ${s.cron}`;
+        });
+        sections.push(`🕐 Scheduled tasks\n${lines.join("\n")}`);
+      }
+
+      if (sections.length === 0) {
+        await reply("No active notifications. You're all clear!");
+        return;
+      }
+
+      await reply(`📋 Active notifications\n\n${sections.join("\n\n")}`);
+    },
+  },
+};

--- a/plugins/reminder.js
+++ b/plugins/reminder.js
@@ -27,6 +27,8 @@ const activeTimeouts = new Map();
 
 // Store references for sending reminders
 let _channels = null;
+let _registerNotification = null;
+let _unregisterNotification = null;
 
 /**
  * Ensure data directory exists
@@ -211,6 +213,15 @@ function scheduleRecurring(recurring) {
 
   const timeoutId = setTimeout(() => sendRecurringReminder(recurring), delay);
   activeTimeouts.set(recurring.id, timeoutId);
+  if (_registerNotification) {
+    _registerNotification(recurring.id, {
+      pluginName: "reminder",
+      label: recurring.text,
+      type: "recurring",
+      nextAt: next.toISOString(),
+      meta: { hour: recurring.hour, minute: recurring.minute },
+    });
+  }
 }
 
 /**
@@ -313,6 +324,7 @@ async function sendReminder(reminder) {
   const reminders = loadReminders().filter(r => r.id !== reminder.id);
   saveReminders(reminders);
   activeTimeouts.delete(reminder.id);
+  if (_unregisterNotification) _unregisterNotification(reminder.id);
 }
 
 /**
@@ -336,15 +348,23 @@ function scheduleReminder(reminder) {
   const now = Date.now();
   const triggerAt = new Date(reminder.triggerAt).getTime();
   const delay = triggerAt - now;
-  
+
   if (delay <= 0) {
     // Already past due, send immediately
     sendReminder(reminder);
     return;
   }
-  
+
   const timeoutId = setTimeout(() => sendReminder(reminder), delay);
   activeTimeouts.set(reminder.id, timeoutId);
+  if (_registerNotification) {
+    _registerNotification(reminder.id, {
+      pluginName: "reminder",
+      label: reminder.text,
+      type: "reminder",
+      nextAt: reminder.triggerAt,
+    });
+  }
 }
 
 /**
@@ -485,6 +505,7 @@ export default {
         }
 
         saveToHistory(cancelled, "cancelled");
+        if (_unregisterNotification) _unregisterNotification(cancelled.id);
 
         const updatedReminders = reminders.filter(r => r.id !== cancelled.id);
         saveReminders(updatedReminders);
@@ -512,6 +533,7 @@ export default {
         }
 
         saveToHistory(cancelled, "cancelled");
+        if (_unregisterNotification) _unregisterNotification(cancelled.id);
 
         const updatedRecurring = recurring.filter(r => r.id !== cancelled.id);
         saveRecurring(updatedRecurring);
@@ -608,8 +630,10 @@ export default {
   },
 
   // Initialize plugin and restore pending reminders on startup
-  init: async ({ channels }) => {
+  init: async ({ channels, registerNotification, unregisterNotification }) => {
     _channels = channels;
+    _registerNotification = registerNotification || null;
+    _unregisterNotification = unregisterNotification || null;
     restoreReminders();
     restoreRecurring();
   },

--- a/src/plugin-loader.js
+++ b/src/plugin-loader.js
@@ -29,11 +29,40 @@ const commandHandlers = new Map();
 const messageHandlers = [];
 // Track scheduled tasks so we can stop them on reload
 const scheduledTasks = [];
+// Track schedule metadata for introspection (plugin name + cron expression)
+const scheduleRegistry = [];
 // Track plugin destroy functions for cleanup on reload
 const destroyHandlers = [];
+// Notification registry: plugins register active notifications for cross-plugin visibility
+// Map<string, { pluginName, label, type, nextAt?, meta? }>
+const notificationRegistry = new Map();
 
 // Store references for use in handlers
 let _runClaude, _config, _channels;
+
+/**
+ * Register an active notification (reminder, scheduled task, etc.) for cross-plugin visibility.
+ * @param {string} id - Unique ID for this notification
+ * @param {Object} info - { pluginName, label, type, nextAt?, meta? }
+ */
+function registerNotification(id, info) {
+  notificationRegistry.set(id, info);
+}
+
+/**
+ * Remove a notification from the registry.
+ * @param {string} id - The notification ID to remove
+ */
+function unregisterNotification(id) {
+  notificationRegistry.delete(id);
+}
+
+/**
+ * Get all registered notifications from all plugins.
+ */
+function getRegisteredNotifications() {
+  return [...notificationRegistry.values()];
+}
 
 /**
  * Discover plugin files from plugins/ and plugins/local/ directories.
@@ -114,16 +143,21 @@ export async function loadPlugins({ channels, config, runClaude }) {
           const task = cron.schedule(schedule.cron, async () => {
             console.log(`[plugins] Running scheduled task for: ${plugin.name}`);
             try {
-              await schedule.handler({ 
-                channels: _channels, 
-                config: _config, 
-                claude: _runClaude 
+              await schedule.handler({
+                channels: _channels,
+                config: _config,
+                claude: _runClaude
               });
             } catch (err) {
               console.error(`[plugins] Scheduled task error (${plugin.name}):`, err.message);
             }
           });
           scheduledTasks.push(task);
+          scheduleRegistry.push({
+            pluginName: plugin.name,
+            cron: schedule.cron,
+            label: schedule.label || null,
+          });
           console.log(`[plugins]   Scheduled task: ${schedule.cron}`);
         }
       }
@@ -153,6 +187,8 @@ export async function loadPlugins({ channels, config, runClaude }) {
             channels: _channels,
             config: _config,
             claude: _runClaude,
+            registerNotification,
+            unregisterNotification,
           });
           console.log(`[plugins]   Initialized`);
         } catch (err) {
@@ -217,6 +253,10 @@ export async function handlePluginMessage(msg) {
     channel,
     channels: _channels,
     getRegisteredCommands,
+    getRegisteredSchedules,
+    registerNotification,
+    unregisterNotification,
+    getRegisteredNotifications,
   };
   
   // Handle .commands
@@ -280,6 +320,8 @@ export async function reloadPlugins() {
     }
   }
   scheduledTasks.length = 0;
+  scheduleRegistry.length = 0;
+  notificationRegistry.clear();
 
   // Clear existing handlers
   commandHandlers.clear();
@@ -337,6 +379,11 @@ export async function reloadPlugins() {
             }
           });
           scheduledTasks.push(task);
+          scheduleRegistry.push({
+            pluginName: plugin.name,
+            cron: schedule.cron,
+            label: schedule.label || null,
+          });
           console.log(`[plugins]   Scheduled task: ${schedule.cron}`);
         }
       }
@@ -366,6 +413,8 @@ export async function reloadPlugins() {
             channels: _channels,
             config: _config,
             claude: _runClaude,
+            registerNotification,
+            unregisterNotification,
           });
           console.log(`[plugins]   Initialized`);
         } catch (err) {
@@ -402,6 +451,13 @@ export function getRegisteredCommands() {
 }
 
 /**
+ * Get all registered schedules with their plugin names and cron expressions
+ */
+export function getRegisteredSchedules() {
+  return [...scheduleRegistry];
+}
+
+/**
  * Run all plugin destroy handlers and stop scheduled tasks.
  * Called during graceful shutdown to clean up timers, connections, etc.
  */
@@ -423,4 +479,4 @@ export async function destroyPlugins() {
   }
 }
 
-export default { loadPlugins, handlePluginMessage, reloadPlugins, getRegisteredCommands, destroyPlugins };
+export default { loadPlugins, handlePluginMessage, reloadPlugins, getRegisteredCommands, getRegisteredSchedules, getRegisteredNotifications, destroyPlugins };


### PR DESCRIPTION
## Summary

Adds a new `.notifications` command to list all active scheduled notifications across plugins (reminders, recurring, other plugin notifications) plus cron-based scheduled tasks.

## Changes

* **New plugin:** `plugins/notifications.js`

  * Implements `.notifications` output grouped by **Reminders**, **Recurring**, **Other**, and **Scheduled tasks**
* **Plugin loader:** `src/plugin-loader.js`

  * Adds a global `notificationRegistry` with `registerNotification` / `unregisterNotification` and `getRegisteredNotifications()`
  * Adds `scheduleRegistry` + `getRegisteredSchedules()` for cron introspection
  * Wires registry helpers into plugin `init()` and command context; clears registries on reload
* **Reminder plugin:** `plugins/reminder.js`

  * Registers reminder + recurring entries on schedule
  * Unregisters entries when sent/cancelled
  * Accepts `registerNotification` / `unregisterNotification` via `init()`

## How to test

* Create a reminder + recurring reminder, then run `.notifications` to verify they appear with “next in …”
* Add/confirm a cron schedule from any plugin and verify it shows under “Scheduled tasks”
* Cancel a reminder/recurring and confirm it disappears from `.notifications`
