### PR TITLE
feat: add Codex provider support and provider configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,6 +16,11 @@ TELEGRAM_BOT_TOKEN=your-telegram-bot-token
 # ANTHROPIC_API_KEY=sk-ant-api03-...
 
 # ============================================
+# AI PROVIDER
+# ============================================
+# AI_PROVIDER=claude
+
+# ============================================
 # CLAUDE CLI SETTINGS
 # ============================================
 # CLAUDE_PATH=claude
@@ -29,6 +34,14 @@ TELEGRAM_BOT_TOKEN=your-telegram-bot-token
 # WEB_SEARCH_TIMEOUT_MS=30000
 # Grant access to additional directories (beyond working dir)
 # CLAUDE_ALLOWED_DIRECTORIES=/path/to/dir1,/path/to/dir2
+
+# ============================================
+# CODEX CLI SETTINGS
+# ============================================
+# CODEX_PATH=codex
+# CODEX_TIMEOUT_MS=180000
+# CODEX_MODEL=gpt-5-codex
+# CODEX_EXTRA_PATH=/usr/local/bin:/opt/homebrew/bin
 
 # ============================================
 # PLUGINS

--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
 # 🦪 Oyster Bot
 
-> Inspired by [OpenClaw](https://github.com/openclaw/openclaw) — but ultra-lightweight and very straightforward. No gateway, no daemon, no native apps. Just a simple bot that wraps [Claude Code CLI](https://docs.claude.com/en/docs/claude-code) and sends responses to your messaging app.
+> Inspired by [OpenClaw](https://github.com/openclaw/openclaw) — but ultra-lightweight and very straightforward. No gateway, no daemon, no native apps. Just a simple bot that wraps AI CLIs (Claude Code or Codex) and sends responses to your messaging app.
 
 <img src="oyster.png" width="150" alt="Oyster">
 
-Chat with Claude, search the web, read files, and run commands—all from your phone.
+Chat with Claude or Codex, search the web, read files, and run commands-all from your phone.
 
 ## Features
 
-- **Conversational AI** — Chat with Claude through Telegram
+- **Conversational AI** — Chat through Telegram using Claude CLI or Codex CLI
 - **Session continuity** — Maintains conversation history per chat
 - **Streaming logs** — See Claude's thinking and tool usage in real-time
 - **Configurable tools** — Control which tools Claude can use
@@ -18,7 +18,7 @@ Chat with Claude, search the web, read files, and run commands—all from your p
 ## Prerequisites
 
 - Node.js 18+
-- [Claude Code CLI](https://docs.claude.com/en/docs/claude-code) installed and authenticated
+- [Claude Code CLI](https://docs.claude.com/en/docs/claude-code) and/or Codex CLI installed and authenticated
 - A Telegram bot token (see below)
 
 ### Claude Code Authentication
@@ -89,6 +89,12 @@ Create a `.env` file with the following variables:
 | `HANDLER_TIMEOUT_MS` | `300000` | Telegraf handler timeout (5 min) |
 | `MAX_MESSAGE_LENGTH` | `4096` | Max chars before splitting messages |
 
+### Optional - AI Provider
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `AI_PROVIDER` | `claude` | Active provider (`claude` or `codex`) |
+
 ### Optional - Claude CLI Settings
 
 | Variable | Default | Description |
@@ -101,6 +107,15 @@ Create a `.env` file with the following variables:
 | `CLAUDE_DANGEROUSLY_SKIP_PERMISSIONS` | `false` | Skip all permission prompts (use with caution) |
 | `CLAUDE_VERBOSE_LOGGING` | `false` | Log all streaming event types |
 | `CLAUDE_ALLOWED_DIRECTORIES` | (none) | Additional directories Claude can access (beyond working dir) |
+
+### Optional - Codex CLI Settings
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `CODEX_PATH` | `codex` | Path to Codex CLI executable |
+| `CODEX_TIMEOUT_MS` | `180000` | Codex process timeout (3 min) |
+| `CODEX_MODEL` | (none) | Optional Codex model override |
+| `CODEX_EXTRA_PATH` | (see config.js) | Additional PATH for Codex subprocess |
 
 ### Optional - Plugin Settings
 
@@ -121,6 +136,9 @@ TELEGRAM_BOT_TOKEN=your-telegram-bot-token
 
 # Restrict to your Telegram user ID
 ALLOWED_USER_IDS=123456789
+
+# Provider: claude or codex
+AI_PROVIDER=claude
 
 # Allow git and npm commands
 CLAUDE_ALLOWED_TOOLS=Read,Glob,Grep,WebSearch,WebFetch,Bash(git *),Bash(npm *)
@@ -218,6 +236,7 @@ The PM2 config includes crash loop protection:
 | `/start` | Show welcome message and help |
 | `/reset` | Clear conversation history |
 | `/session` | Show current session ID |
+| `/switch <claude\|codex>` | Switch active AI provider |
 
 ## Plugins
 
@@ -319,7 +338,7 @@ export default {
   - `msg.channelId` — Chat/room ID
 - `reply(text)` — Send a response to the same channel
 - `sendTyping()` — Show typing indicator
-- `claude(prompt)` — Run a prompt through Claude CLI
+- `claude(prompt)` — Run a prompt through the active AI provider (Claude or Codex)
 - `config` — App configuration object
 - `channels` — Map of channel instances (for scheduled tasks)
 
@@ -335,7 +354,9 @@ export default {
 oyster-bot/
 ├── src/
 │   ├── app.js            # Main entrypoint (channel-agnostic)
+│   ├── ai.js             # Provider router (Claude/Codex)
 │   ├── claude.js         # Claude CLI wrapper with streaming
+│   ├── codex.js          # Codex CLI wrapper
 │   ├── config.js         # Centralized configuration
 │   ├── plugin-loader.js  # Plugin discovery and registration
 │   ├── channels/         # Channel adapters
@@ -363,7 +384,7 @@ The bot uses a channel-agnostic design that makes it easy to add support for new
 ```
          ┌───────────────────────────────────┐
          │              app.js               │
-         │ (routing, sessions, Claude, etc.) │
+         │ (routing, sessions, provider, etc.) │
          └─────────────────┬─────────────────┘
                            │
                  ┌─────────┴─────────┐
@@ -389,8 +410,8 @@ The bot uses a channel-agnostic design that makes it easy to add support for new
 ## How It Works
 
 1. User sends a message to the Telegram bot
-2. Bot spawns the Claude CLI with `--print --output-format stream-json`
-3. Claude processes the request using allowed tools
+2. Bot picks the active provider (`claude` or `codex`)
+3. Bot spawns the matching CLI and sends your prompt
 4. Streaming events are logged in real-time (thinking, tool use, etc.)
 5. Final response is sent back to the user in Telegram
 

--- a/plugins/git.js
+++ b/plugins/git.js
@@ -13,7 +13,6 @@
  */
 
 import { execSync } from "child_process";
-import { runClaude } from "../src/claude.js";
 
 const GIT_CWD = { cwd: process.cwd(), encoding: "utf8" };
 const MAX_DIFF_CHARS = 8000;
@@ -95,7 +94,7 @@ export default {
       }
     },
 
-    async branch(msg, { reply }) {
+    async branch(msg, { reply, claude }) {
       const args = parseArgs(msg);
       let name = args.join(" ");
 
@@ -119,7 +118,7 @@ export default {
 
             try {
               const prompt = `Generate a short git branch name for these changes. Use format: type/short-description where type is feat, fix, chore, refactor, or docs. Keep the description to 2-4 words max, lowercase, hyphenated. Reply with ONLY the branch name, nothing else.\n\nExample good names: feat/add-user-auth, fix/login-redirect, chore/update-deps\n\nChanges:\n${diff}`;
-              const result = await runClaude(prompt);
+              const result = await claude(prompt);
               name = result.result?.trim().replace(/^["'\`]+|["'\`]+$/g, "").trim();
               name = name?.replace(/[^a-zA-Z0-9/_-]/g, "").slice(0, 50);
             } catch (e) {
@@ -150,7 +149,7 @@ export default {
       }
     },
 
-    async commit(msg, { reply }) {
+    async commit(msg, { reply, claude }) {
       try {
         execSync("git add -A", GIT_CWD);
 
@@ -174,7 +173,7 @@ export default {
           const prompt = `Generate a concise git commit message (1 line, max 72 chars) for these changes. Follow conventional commits style (feat:, fix:, chore:, etc). Reply with ONLY the commit message, nothing else.\n\n${diff}`;
 
           try {
-            const result = await runClaude(prompt);
+            const result = await claude(prompt);
             message = result.result?.trim() || "Update from Telegram";
             message = message.replace(/^["'`]+|["'`]+$/g, "").trim();
           } catch (e) {
@@ -203,7 +202,7 @@ export default {
       }
     },
 
-    async pr(msg, { reply }) {
+    async pr(msg, { reply, claude }) {
       const args = parseArgs(msg);
       let title = args.join(" ");
 
@@ -251,7 +250,7 @@ BODY:
 
         let body = "";
         try {
-          const result = await runClaude(prompt);
+          const result = await claude(prompt);
           const response = result.result?.trim() || "";
 
           const titleMatch = response.match(/TITLE:\s*(.+)/);
@@ -335,7 +334,7 @@ BODY:
       }
     },
 
-    async ship(msg, { reply }) {
+    async ship(msg, { reply, claude }) {
       try {
         const args = parseArgs(msg);
 
@@ -368,7 +367,7 @@ BODY:
 
             try {
               const prompt = `Generate a short git branch name for these changes. Use format: type/short-description where type is feat, fix, chore, refactor, or docs. Keep the description to 2-4 words max, lowercase, hyphenated. Reply with ONLY the branch name, nothing else.\n\nExample good names: feat/add-user-auth, fix/login-redirect, chore/update-deps, docs/api-reference\n\nChanges:\n${diff}`;
-              const result = await runClaude(prompt);
+              const result = await claude(prompt);
               branchName = result.result?.trim().replace(/^["'\`]+|["'\`]+$/g, "").trim();
               branchName = branchName?.replace(/[^a-zA-Z0-9/_-]/g, "").slice(0, 50);
             } catch (e) {
@@ -403,7 +402,7 @@ BODY:
           let commitMsg = "Update from Telegram";
           try {
             const prompt = `Generate a concise git commit message (1 line, max 72 chars) for these changes. Follow conventional commits style (feat:, fix:, chore:, etc). Reply with ONLY the commit message, nothing else.\n\n${diff}`;
-            const result = await runClaude(prompt);
+            const result = await claude(prompt);
             commitMsg = result.result?.trim().replace(/^["'\`]+|["'\`]+$/g, "").trim() || commitMsg;
           } catch (e) {
             console.error("[git] Failed to generate commit message:", e.message);
@@ -463,7 +462,7 @@ BODY:
 - Key changes (bullet points)
 - Any notes for reviewers>`;
 
-            const result = await runClaude(prompt);
+            const result = await claude(prompt);
             const response = result.result?.trim() || "";
 
             const titleMatch = response.match(/TITLE:\s*(.+)/);

--- a/src/ai.js
+++ b/src/ai.js
@@ -1,0 +1,31 @@
+import config from "./config.js";
+import { runClaude } from "./claude.js";
+import { runCodex } from "./codex.js";
+
+export const SUPPORTED_AI_PROVIDERS = ["claude", "codex"];
+
+export function normalizeProvider(provider) {
+  const normalized = String(provider || "").toLowerCase().trim();
+  return SUPPORTED_AI_PROVIDERS.includes(normalized) ? normalized : null;
+}
+
+export function getConfiguredProvider() {
+  return normalizeProvider(config.ai.provider) || "claude";
+}
+
+export async function runAI(prompt, sessionId = null, provider = getConfiguredProvider()) {
+  const resolvedProvider = normalizeProvider(provider);
+  if (!resolvedProvider) {
+    throw new Error(`Unsupported AI provider: ${provider}. Supported: ${SUPPORTED_AI_PROVIDERS.join(", ")}`);
+  }
+
+  if (resolvedProvider === "codex") {
+    const result = await runCodex(prompt, sessionId);
+    return { ...result, provider: resolvedProvider };
+  }
+
+  const result = await runClaude(prompt, sessionId);
+  return { ...result, provider: resolvedProvider };
+}
+
+export default { runAI, normalizeProvider, getConfiguredProvider, SUPPORTED_AI_PROVIDERS };

--- a/src/app.js
+++ b/src/app.js
@@ -6,15 +6,21 @@
  */
 
 import config from "./config.js";
-import { runClaude } from "./claude.js";
+import { runAI, getConfiguredProvider, normalizeProvider, SUPPORTED_AI_PROVIDERS } from "./ai.js";
 import { createChannels } from "./channels/index.js";
 import { loadPlugins, handlePluginMessage, destroyPlugins } from "./plugin-loader.js";
 import { getSessionKey } from "./types/message.js";
 
-// Per-session tracking: sessionKey -> Claude sessionId
+// Per-session tracking: provider:sessionKey -> sessionId
 const sessions = new Map();
 // Track active requests to prevent concurrent calls per session
 const activeRequests = new Set();
+// Runtime provider can be switched via /switch
+let activeProvider = getConfiguredProvider();
+
+function getProviderSessionKey(provider, sessionKey) {
+  return `${provider}:${sessionKey}`;
+}
 
 /**
  * Split a message into chunks that fit within the limit
@@ -75,8 +81,8 @@ async function handleMessage(msg, channels) {
     return;
   }
 
-  // Route to Claude
-  await handleClaudeMessage(msg, channel);
+  // Route to AI provider
+  await handleAIMessage(msg, channel);
 }
 
 /**
@@ -84,33 +90,51 @@ async function handleMessage(msg, channels) {
  */
 async function handleCommand(msg, channel) {
   const text = msg.text.toLowerCase().trim();
+  const rawText = (msg.text || "").trim();
+  const parts = rawText.split(/\s+/);
   const sessionKey = getSessionKey(msg);
+  const providerSessionKey = getProviderSessionKey(activeProvider, sessionKey);
 
   if (text === "/start") {
     await channel.send(
       msg.channelId,
-      "Hello! I'm a Claude Code bot. Send me any message and I'll respond using Claude.\n\n" +
+      `Hello! I'm an AI CLI bot. Send me any message and I'll respond using ${activeProvider}.\n\n` +
         "Commands:\n" +
         "/start - Show this message\n" +
         "/reset - Clear conversation history\n" +
-        "/session - Show current session info"
+        "/session - Show current session info\n" +
+        "/switch <claude|codex> - Switch AI provider"
     );
     return;
   }
 
   if (text === "/reset") {
-    sessions.delete(sessionKey);
-    await channel.send(msg.channelId, "Conversation reset. Starting fresh.");
+    sessions.delete(providerSessionKey);
+    await channel.send(msg.channelId, `Conversation reset for provider: ${activeProvider}`);
     return;
   }
 
   if (text === "/session") {
-    const sessionId = sessions.get(sessionKey);
+    const sessionId = sessions.get(providerSessionKey);
     if (sessionId) {
-      await channel.send(msg.channelId, `Active session: ${sessionId}`);
+      await channel.send(msg.channelId, `Provider: ${activeProvider}\nActive session: ${sessionId}`);
     } else {
-      await channel.send(msg.channelId, "No active session. Send a message to start one.");
+      await channel.send(msg.channelId, `Provider: ${activeProvider}\nNo active session. Send a message to start one.`);
     }
+    return;
+  }
+
+  if (parts[0]?.toLowerCase() === "/switch") {
+    const requestedProvider = normalizeProvider(parts[1]);
+    if (!requestedProvider) {
+      await channel.send(
+        msg.channelId,
+        `Usage: /switch <provider>\nAvailable providers: ${SUPPORTED_AI_PROVIDERS.join(", ")}`
+      );
+      return;
+    }
+    activeProvider = requestedProvider;
+    await channel.send(msg.channelId, `Switched AI provider to: ${activeProvider}`);
     return;
   }
 
@@ -118,18 +142,20 @@ async function handleCommand(msg, channel) {
 }
 
 /**
- * Handle a message that should go to Claude
+ * Handle a message that should go to configured AI provider
  */
-async function handleClaudeMessage(msg, channel) {
+async function handleAIMessage(msg, channel) {
   const sessionKey = getSessionKey(msg);
+  const provider = activeProvider;
+  const providerSessionKey = getProviderSessionKey(provider, sessionKey);
 
   // Prevent concurrent requests per session
-  if (activeRequests.has(sessionKey)) {
+  if (activeRequests.has(providerSessionKey)) {
     await channel.send(msg.channelId, "Still processing your previous message. Please wait.");
     return;
   }
 
-  activeRequests.add(sessionKey);
+  activeRequests.add(providerSessionKey);
 
   // Start typing indicator
   await channel.sendTyping(msg.channelId);
@@ -138,12 +164,12 @@ async function handleClaudeMessage(msg, channel) {
   }, 4000);
 
   try {
-    const sessionId = sessions.get(sessionKey);
-    const result = await runClaude(msg.text, sessionId);
+    const sessionId = sessions.get(providerSessionKey);
+    const result = await runAI(msg.text, sessionId, provider);
 
     // Store session ID for conversation continuity
     if (result.session_id) {
-      sessions.set(sessionKey, result.session_id);
+      sessions.set(providerSessionKey, result.session_id);
     }
 
     // Extract the text response
@@ -160,7 +186,7 @@ async function handleClaudeMessage(msg, channel) {
     await channel.send(msg.channelId, `Error: ${err.message.slice(0, 500)}`);
   } finally {
     clearInterval(typingInterval);
-    activeRequests.delete(sessionKey);
+    activeRequests.delete(providerSessionKey);
   }
 }
 
@@ -181,7 +207,7 @@ async function start() {
   }
 
   // Load plugins
-  await loadPlugins({ channels, config, runClaude });
+  await loadPlugins({ channels, config, runClaude: (prompt, sessionId = null) => runAI(prompt, sessionId, activeProvider) });
 
   // Start all channels
   for (const [type, channel] of channels) {

--- a/src/codex.js
+++ b/src/codex.js
@@ -1,0 +1,101 @@
+import { spawn } from "child_process";
+import { mkdtempSync, readFileSync, rmSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+import config from "./config.js";
+
+/**
+ * Run a prompt through Codex CLI in non-interactive mode.
+ * Returns plain-text result.
+ */
+export function runCodex(prompt, sessionId = null) {
+  return new Promise((resolve, reject) => {
+    const tempDir = mkdtempSync(join(tmpdir(), "oyster-codex-"));
+    const outFile = join(tempDir, "last-message.txt");
+
+    const args = [
+      "exec",
+      "--color", "never",
+      "--output-last-message", outFile,
+    ];
+
+    if (config.codex.model) {
+      args.push("--model", config.codex.model);
+    }
+
+    // Codex conversation resume mode differs from Claude; keep stateless for now.
+    void sessionId;
+    args.push(prompt);
+
+    console.log(`[codex] spawning: ${config.codex.path} ${args.join(" ").slice(0, 120)}...`);
+
+    const proc = spawn(config.codex.path, args, {
+      env: {
+        ...process.env,
+        PATH: `${config.codex.extraPath}:${process.env.PATH || ""}`,
+      },
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+
+    let stdout = "";
+    let stderr = "";
+    const timeout = setTimeout(() => {
+      proc.kill("SIGTERM");
+      reject(new Error(`Codex timed out after ${config.codex.timeoutMs / 1000}s`));
+    }, config.codex.timeoutMs);
+
+    proc.stdout.on("data", (chunk) => {
+      stdout += chunk.toString();
+    });
+
+    proc.stderr.on("data", (chunk) => {
+      const text = chunk.toString();
+      stderr += text;
+      if (text.trim()) console.log(`[codex stderr] ${text.trim()}`);
+    });
+
+    proc.on("close", (code) => {
+      clearTimeout(timeout);
+      console.log(`[codex] exited with code ${code}`);
+
+      try {
+        if (code !== 0) {
+          throw new Error(`Codex exited with code ${code}: ${stderr.slice(0, 500) || stdout.slice(0, 500)}`);
+        }
+
+        let resultText = "";
+        try {
+          resultText = readFileSync(outFile, "utf8").trim();
+        } catch {
+          resultText = stdout.trim();
+        }
+
+        resolve({
+          result: resultText || "No response received",
+          session_id: null,
+        });
+      } catch (err) {
+        reject(err);
+      } finally {
+        try {
+          rmSync(tempDir, { recursive: true, force: true });
+        } catch {
+          // Best-effort cleanup
+        }
+      }
+    });
+
+    proc.on("error", (err) => {
+      clearTimeout(timeout);
+      try {
+        rmSync(tempDir, { recursive: true, force: true });
+      } catch {
+        // Best-effort cleanup
+      }
+      console.error("[codex] spawn error:", err.message);
+      reject(err);
+    });
+  });
+}
+
+export default { runCodex };

--- a/src/config.js
+++ b/src/config.js
@@ -48,6 +48,9 @@ export const config = {
 
   // Global settings
   maxMessageLength: Number(process.env.MAX_MESSAGE_LENGTH) || 4096,
+  ai: {
+    provider: (process.env.AI_PROVIDER || "claude").toLowerCase(),
+  },
 
   // Claude CLI
   claude: {
@@ -66,6 +69,14 @@ export const config = {
     allowedDirectories: process.env.CLAUDE_ALLOWED_DIRECTORIES
       ? process.env.CLAUDE_ALLOWED_DIRECTORIES.split(",").map((d) => d.trim())
       : null,
+  },
+
+  // Codex CLI
+  codex: {
+    path: process.env.CODEX_PATH || "codex",
+    timeoutMs: Number(process.env.CODEX_TIMEOUT_MS) || 180_000, // 3 minutes
+    model: process.env.CODEX_MODEL || null,
+    extraPath: process.env.CODEX_EXTRA_PATH || "/usr/local/bin:/opt/homebrew/bin",
   },
 
   // Plugins


### PR DESCRIPTION
### Summary
This PR adds Codex as a supported AI backend alongside Claude and introduces provider-level configuration. It also updates docs and plugin integration points to work with the active provider abstraction.

### Key changes
- Added new environment/config options for provider selection:
  - `AI_PROVIDER` (`claude` or `codex`)
  - Codex settings: `CODEX_PATH`, `CODEX_TIMEOUT_MS`, `CODEX_MODEL`, `CODEX_EXTRA_PATH`
- Updated `.env.example` with dedicated AI provider and Codex CLI sections.
- Expanded `README.md` to document dual-provider support, setup, config variables, architecture updates, and `/switch <claude|codex>` command.
- Updated plugin usage to call the injected `claude(prompt)` helper (now routed through the active provider) instead of directly importing Claude-specific execution logic.
- Reflected architectural changes in docs (`src/ai.js` router and `src/codex.js` wrapper).

### Notes for reviewers
- Verify provider switching behavior and fallback/default behavior when `AI_PROVIDER` is unset.
- Confirm Codex CLI path/timeouts/model override handling across environments.
- Spot-check plugins (especially git plugin flows) to ensure provider-agnostic prompt execution remains unchanged functionally.