### PR TITLE
feat(notifications): human-readable cron schedule display

### DIFF
--- a/plugins/notifications.js
+++ b/plugins/notifications.js
@@ -25,6 +25,46 @@ function formatClockTime(hour, minute) {
     : `${displayHour}:${String(minute).padStart(2, "0")}${period}`;
 }
 
+function parseIntegerField(value, min, max) {
+  if (!/^\d+$/.test(value)) return null;
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed < min || parsed > max) return null;
+  return parsed;
+}
+
+function formatCronSchedule(cronExpr) {
+  const parts = String(cronExpr || "").trim().split(/\s+/);
+  if (parts.length !== 5 && parts.length !== 6) return `schedule: \`${cronExpr}\``;
+
+  // Support both 5-field and 6-field formats; ignore seconds when present.
+  const [minuteField, hourField, dayOfMonthField, monthField, dayOfWeekField] =
+    parts.length === 6 ? parts.slice(1) : parts;
+
+  const minute = parseIntegerField(minuteField, 0, 59);
+  const hour = parseIntegerField(hourField, 0, 23);
+
+  if (minute !== null && hour !== null) {
+    const atTime = formatClockTime(hour, minute);
+    if (dayOfMonthField === "*" && monthField === "*" && dayOfWeekField === "*") {
+      return `daily at ${atTime} (local time)`;
+    }
+    return `at ${atTime} (local time, cron: \`${cronExpr}\`)`;
+  }
+
+  if (/^\*\/\d+$/.test(minuteField) && hourField === "*" && dayOfMonthField === "*" && monthField === "*" && dayOfWeekField === "*") {
+    const interval = Number(minuteField.slice(2));
+    if (interval > 0) {
+      return `every ${interval} minute${interval === 1 ? "" : "s"} (local time)`;
+    }
+  }
+
+  if (minute !== null && hourField === "*" && dayOfMonthField === "*" && monthField === "*" && dayOfWeekField === "*") {
+    return `hourly at :${String(minute).padStart(2, "0")} (local time)`;
+  }
+
+  return `schedule: \`${cronExpr}\``;
+}
+
 export default {
   name: "notifications",
 
@@ -74,7 +114,7 @@ export default {
       if (schedules.length > 0) {
         const lines = schedules.map((s, i) => {
           const label = s.label || s.pluginName;
-          return `  ${i + 1}. ${label} — ${s.cron}`;
+          return `  ${i + 1}. ${label} — ${formatCronSchedule(s.cron)}`;
         });
         sections.push(`🕐 Scheduled tasks\n${lines.join("\n")}`);
       }


### PR DESCRIPTION
### Summary
Improve scheduled task output in notifications by converting common cron patterns into readable local-time text. This makes cron-based schedules easier to understand at a glance while preserving raw cron for complex cases.

### Key changes
- Added `parseIntegerField(value, min, max)` to safely validate numeric cron fields.
- Added `formatCronSchedule(cronExpr)` to humanize supported cron expressions.
- Supported both 5-field and 6-field cron formats (ignores seconds when present).
- Added readable formatting for:
  - Daily fixed times (`daily at 8:30AM (local time)`)
  - Every-N-minute intervals (`every 15 minutes (local time)`)
  - Hourly-at-minute schedules (`hourly at :05 (local time)`)
- Kept fallback behavior for unsupported/complex patterns: `schedule: \`<cron>\``.
- Updated scheduled task list rendering to use `formatCronSchedule(s.cron)`.

### Notes for reviewers
- Existing behavior is preserved for non-standard cron expressions via fallback text.
- Humanized output now explicitly labels times as local time.
- For fixed-time non-daily patterns, raw cron is included in parentheses for clarity.