### PR TITLE
feat: recursive plugin discovery, evolve suggestions reconciliation, and stable path resolution

### DIFF
--- a/ecosystem.config.cjs
+++ b/ecosystem.config.cjs
@@ -14,6 +14,7 @@ module.exports = {
   apps: [{
     name: 'oyster-bot',
     script: 'src/app.js',
+    cwd: __dirname,               // Resolve relative paths (.env, plugins, logs) from repo root
     
     // Crash loop protection
     max_restarts: 10,              // Max restarts before giving up

--- a/src/plugin-loader.js
+++ b/src/plugin-loader.js
@@ -1,4 +1,4 @@
-import { readdirSync, existsSync, readFileSync, writeFileSync, statSync } from "fs";
+import { readdirSync, existsSync, readFileSync, writeFileSync, statSync, mkdirSync } from "fs";
 import { join, dirname } from "path";
 import { fileURLToPath, pathToFileURL } from "url";
 import cron from "node-cron";
@@ -50,6 +50,57 @@ function loadJsonArray(filePath) {
   } catch (err) {
     console.error(`[plugins] Failed to read JSON array from ${filePath}:`, err.message);
     return [];
+  }
+}
+
+function mergeSuggestionArrays(arrays) {
+  const merged = [];
+  const seen = new Set();
+  for (const list of arrays) {
+    if (!Array.isArray(list)) continue;
+    for (const item of list) {
+      if (!item || typeof item !== "object") continue;
+      const key = JSON.stringify({
+        name: item.name || "",
+        description: item.description || "",
+        complexity: item.complexity || "",
+        suggestedAt: item.suggestedAt || "",
+      });
+      if (seen.has(key)) continue;
+      seen.add(key);
+      merged.push(item);
+    }
+  }
+  merged.sort((a, b) => {
+    const at = new Date(a?.suggestedAt || 0).getTime();
+    const bt = new Date(b?.suggestedAt || 0).getTime();
+    return at - bt;
+  });
+  return merged;
+}
+
+function reconcileEvolveSuggestions(sourcePluginPath = null) {
+  try {
+    const targetFile = join(getDataDir(_config), "evolve-suggestions.json");
+    const candidateFiles = [targetFile];
+
+    if (sourcePluginPath) {
+      const sourceFile = join(dirname(sourcePluginPath), "..", "..", "data", "evolve-suggestions.json");
+      if (!candidateFiles.includes(sourceFile)) {
+        candidateFiles.push(sourceFile);
+      }
+    }
+
+    const merged = mergeSuggestionArrays(candidateFiles.map((file) => loadJsonArray(file)));
+    const current = loadJsonArray(targetFile);
+
+    if (JSON.stringify(current) !== JSON.stringify(merged)) {
+      mkdirSync(dirname(targetFile), { recursive: true });
+      writeFileSync(targetFile, JSON.stringify(merged, null, 2));
+      console.log(`[plugins] Reconciled evolve suggestions (${merged.length} ideas)`);
+    }
+  } catch (err) {
+    console.error("[plugins] Evolve suggestions reconcile failed:", err.message);
   }
 }
 
@@ -164,19 +215,54 @@ function getRegisteredNotifications() {
 function discoverPluginFiles() {
   const files = [];
   const pluginDirs = getPluginDirs(_config);
-  for (const dir of pluginDirs) {
+  console.log(`[plugins] Scanning directories: ${pluginDirs.join(", ") || "(none)"}`);
+
+  const walk = (dir) => {
+    let entries;
     try {
-      if (!existsSync(dir)) continue;
-      const entries = readdirSync(dir).filter((f) => f.endsWith(".js"));
-      for (const f of entries) {
-        files.push(join(dir, f));
-      }
+      entries = readdirSync(dir, { withFileTypes: true });
     } catch (err) {
-      if (err.code !== "ENOENT") {
+      if (err.code === "ENOENT") {
+        console.warn(`[plugins] Directory not found: ${dir}`);
+      } else {
         console.error(`[plugins] Error reading ${dir}:`, err.message);
       }
+      return;
     }
+
+    for (const entry of entries) {
+      const entryPath = join(dir, entry.name);
+      if (entry.isDirectory()) {
+        walk(entryPath);
+        continue;
+      }
+
+      if (entry.isSymbolicLink()) {
+        try {
+          const target = statSync(entryPath);
+          if (target.isDirectory()) {
+            walk(entryPath);
+            continue;
+          }
+          if (target.isFile() && /\.(?:cjs|mjs|js)$/i.test(entry.name)) {
+            files.push(entryPath);
+          }
+        } catch (err) {
+          console.warn(`[plugins] Failed to follow symlink: ${entryPath} (${err.message})`);
+        }
+        continue;
+      }
+
+      if (/\.(?:cjs|mjs|js)$/i.test(entry.name)) {
+        files.push(entryPath);
+      }
+    }
+  };
+
+  for (const dir of pluginDirs) {
+    walk(dir);
   }
+
   return files;
 }
 
@@ -221,6 +307,7 @@ export async function loadPlugins({ channels, config, runClaude }) {
             handler,
             pluginName: plugin.name,
             description: helpMap[cmdName] || null,
+            pluginFilePath: filePath,
           });
           console.log(`[plugins]   Registered command: .${cmdName}`);
         }
@@ -297,6 +384,7 @@ export async function loadPlugins({ channels, config, runClaude }) {
   }
 
   reconcileBusinessIdeas({ force: true });
+  reconcileEvolveSuggestions();
   if (businessIdeasReconcileInterval) {
     clearInterval(businessIdeasReconcileInterval);
     businessIdeasReconcileInterval = null;
@@ -373,6 +461,9 @@ export async function handlePluginMessage(msg) {
         await cmd.handler(msg, helpers);
         if (cmdName === "idea" || cmdName === "cook" || cmdName === "idealist") {
           reconcileBusinessIdeas({ force: true });
+        }
+        if (cmdName === "evolve") {
+          reconcileEvolveSuggestions(cmd.pluginFilePath);
         }
         return true;
       } catch (err) {
@@ -463,6 +554,7 @@ export async function reloadPlugins() {
             handler,
             pluginName: plugin.name,
             description: helpMap[cmdName] || null,
+            pluginFilePath: filePath,
           });
           console.log(`[plugins]   Registered command: .${cmdName}`);
         }
@@ -542,6 +634,7 @@ export async function reloadPlugins() {
 
   console.log(`[plugins] Reloaded ${loadedPlugins.length} plugin(s): ${loadedPlugins.join(", ") || "none"}`);
   reconcileBusinessIdeas({ force: true });
+  reconcileEvolveSuggestions();
   businessIdeasReconcileInterval = setInterval(() => {
     reconcileBusinessIdeas();
   }, 60_000);

--- a/src/runtime-paths.js
+++ b/src/runtime-paths.js
@@ -1,9 +1,20 @@
-import { isAbsolute, resolve } from "path";
+import { homedir } from "os";
+import { dirname, isAbsolute, resolve } from "path";
+import { fileURLToPath } from "url";
+
+const appRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+
+function expandHomeDir(input) {
+  if (input === "~") return homedir();
+  if (input.startsWith("~/")) return resolve(homedir(), input.slice(2));
+  return input;
+}
 
 function resolvePath(input, fallback) {
   const raw = (input || fallback || "").trim();
-  if (!raw) return resolve(process.cwd());
-  return isAbsolute(raw) ? raw : resolve(process.cwd(), raw);
+  if (!raw) return appRoot;
+  const expanded = expandHomeDir(raw);
+  return isAbsolute(expanded) ? expanded : resolve(appRoot, expanded);
 }
 
 function parsePathList(input) {
@@ -31,4 +42,3 @@ export function getPluginDirs(config = null) {
 
   return [resolvePath(process.env.PLUGIN_DIR, "./plugins")];
 }
-


### PR DESCRIPTION
## Summary
Improves the plugin loader with recursive directory scanning, adds reconciliation for evolve suggestions data, and stabilizes path resolution to use the app root instead of `process.cwd()`.

## Key changes
- **Recursive plugin discovery**: `discoverPluginFiles()` now walks subdirectories and follows symlinks, supporting `.js`, `.cjs`, and `.mjs` files
- **Evolve suggestions reconciliation**: New `mergeSuggestionArrays()` and `reconcileEvolveSuggestions()` functions deduplicate and merge evolve suggestion data across plugin and data directories, triggered on load/reload and after `.evolve` commands
- **Stable path resolution**: `runtime-paths.js` now resolves relative paths against the app root (`__dirname`-based) instead of `process.cwd()`, with `~` home directory expansion support
- **PM2 `cwd` pinning**: `ecosystem.config.cjs` sets `cwd: __dirname` so PM2 resolves relative paths from the repo root regardless of where `pm2 start` is invoked
- **`pluginFilePath` tracking**: Commands now carry their source file path, enabling evolve reconciliation to locate plugin-local data files

## Notes for reviewers
- The recursive walk intentionally has no depth limit — plugin directories are expected to be shallow. If this becomes a concern, a max-depth guard can be added later.
- Path resolution change from `process.cwd()` to app root may affect setups that relied on launching from a specific directory — the PM2 `cwd` change ensures consistency for that case.