### PR TITLE
feat(orchestrator): add goal tracking and daily check-in plugin

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -63,3 +63,7 @@ TELEGRAM_BOT_TOKEN=your-telegram-bot-token
 # WEATHER_CRON=0 8 * * *
 # Temperature units: "fahrenheit" or "celsius" (default: fahrenheit)
 # WEATHER_UNITS=fahrenheit
+
+# Orchestrator plugin
+# ORCHESTRATOR_CRON=0 9 * * *
+# ORCHESTRATOR_ENABLED=true

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,6 @@ node_modules
 .env
 data/
 logs/
-plugins/local/
+plugins/local
 TODO.md
 CLAUDE.md

--- a/README.md
+++ b/README.md
@@ -128,6 +128,8 @@ Create a `.env` file with the following variables:
 | `QUOTES_CRON` | `0 * * * *` | Cron schedule for quotes (default: hourly) |
 | `WEATHER_DEFAULT_LOCATION` | (none) | Default location for weather (e.g., "Seattle, WA") |
 | `WEATHER_CRON` | `0 8 * * *` | Cron schedule for daily weather (default: 8am) |
+| `ORCHESTRATOR_CRON` | `0 9 * * *` | Cron schedule for orchestrator check-ins (default: 9am) |
+| `ORCHESTRATOR_ENABLED` | `true` | Enable/disable scheduled orchestrator check-ins |
 
 ### Example `.env`
 
@@ -290,6 +292,47 @@ Git workflow (commit, PR, merge from Telegram):
 - `.weather <location>` — Get weather for a specific place
 - Scheduled weather — Sends daily weather report
 
+**Orchestrator Plugin** (`plugins/orchestrator.js`)
+
+A self-organizing agent that helps you achieve goals through daily check-ins.
+
+Commands:
+- `.goal <text>` — Add a goal (e.g., `.goal Build an audience around AI content`)
+- `.goals` — List your active goals
+- `.rmgoal <n>` — Pause a goal by number
+- `.oidea <text>` — Add an idea for your primary goal
+- `.ideas` — View tracked ideas by status
+- `.checkin` — Trigger a check-in now (or wait for schedule)
+- `.approve` — Approve the pending proposal
+- `.reject [feedback]` — Reject with optional feedback
+- `.ostatus` — View orchestrator status
+
+Example workflow:
+```
+.goal Build an audience around AI content - I have a newsletter
+
+.checkin
+
+# Claude proposes actions:
+# 🎯 Daily Check-in
+# 1. Research successful AI newsletters
+# 2. Draft outline for "state of AI agents" post
+#
+# Reply .approve to proceed, or .reject [feedback]
+
+.approve
+
+# ✅ Approved! Here's today's focus:
+# 1. Research successful AI newsletters
+# 2. Draft outline for "state of AI agents" post
+```
+
+Configure in `.env`:
+```bash
+ORCHESTRATOR_CRON=0 9 * * *   # Daily at 9am (default)
+ORCHESTRATOR_ENABLED=true     # Enable scheduled check-ins
+```
+
 Configure in `.env`:
 ```bash
 # Optional runtime paths
@@ -306,7 +349,15 @@ QUOTES_CRON=0 9 * * *
 # Weather settings
 WEATHER_DEFAULT_LOCATION=Seattle, WA
 WEATHER_CRON=0 8 * * *
+
+# Orchestrator settings
+ORCHESTRATOR_CRON=0 9 * * *
+# ORCHESTRATOR_ENABLED=true
 ```
+
+### Local/Private Plugins
+
+For plugins you don't want to commit, put them in `plugins/local/` — it's gitignored and the plugin loader finds them automatically.
 
 ### Creating Your Own Plugin
 
@@ -382,6 +433,7 @@ oyster-bot/
 │   ├── admin.js          # Admin commands (reload, restart, status)
 │   ├── quotes.js         # Motivational quotes plugin
 │   ├── food-diary.js     # Food diary plugin
+│   ├── orchestrator.js   # Goal tracking and daily check-ins
 │   ├── reminder.js       # Reminders plugin
 │   └── weather.js        # Weather plugin
 ├── ecosystem.config.cjs  # PM2 process manager config

--- a/plugins/local
+++ b/plugins/local
@@ -1,1 +1,0 @@
-/Users/tim/Claude/local-oyster-bot-plugins

--- a/plugins/orchestrator.js
+++ b/plugins/orchestrator.js
@@ -1,0 +1,736 @@
+/**
+ * Orchestrator Plugin
+ *
+ * A self-organizing agent that reasons about user goals, generates ideas,
+ * proposes actions, and tracks progress. Runs autonomously on a schedule
+ * but requires human approval for actions.
+ *
+ * Commands:
+ * - .goal <text> — Add a new goal
+ * - .goals — List all active goals
+ * - .rmgoal <id> — Remove/pause a goal
+ * - .ideas — Show current ideas being tracked
+ * - .oidea <text> — Manually add an idea
+ * - .approve — Approve pending proposal
+ * - .reject [reason] — Reject proposal with optional feedback
+ * - .checkin — Trigger manual check-in (don't wait for schedule)
+ * - .ostatus — Show orchestrator state and next scheduled run
+ */
+
+import { readFileSync, writeFileSync, existsSync, mkdirSync } from "fs";
+import { join } from "path";
+import { getDataDir } from "../src/runtime-paths.js";
+
+const DATA_DIR = getDataDir();
+const GOALS_FILE = join(DATA_DIR, "orchestrator-goals.json");
+const IDEAS_FILE = join(DATA_DIR, "orchestrator-ideas.json");
+const STATE_FILE = join(DATA_DIR, "orchestrator-state.json");
+const HISTORY_FILE = join(DATA_DIR, "orchestrator-history.json");
+
+// Store references for scheduled tasks
+let _channels = null;
+let _runClaude = null;
+let _registerNotification = null;
+let _unregisterNotification = null;
+let _scheduledTask = null;
+
+// Get cron schedule from env or use default (9am daily)
+const ORCHESTRATOR_CRON = process.env.ORCHESTRATOR_CRON || "0 9 * * *";
+const ORCHESTRATOR_ENABLED = process.env.ORCHESTRATOR_ENABLED !== "false";
+
+// ============================================================================
+// Data Layer
+// ============================================================================
+
+function ensureDataDir() {
+  if (!existsSync(DATA_DIR)) {
+    mkdirSync(DATA_DIR, { recursive: true });
+  }
+}
+
+function loadJson(filePath, defaultValue = []) {
+  try {
+    if (existsSync(filePath)) {
+      return JSON.parse(readFileSync(filePath, "utf-8"));
+    }
+  } catch (err) {
+    console.error(`[orchestrator] Error loading ${filePath}:`, err.message);
+  }
+  return defaultValue;
+}
+
+function saveJson(filePath, data) {
+  ensureDataDir();
+  writeFileSync(filePath, JSON.stringify(data, null, 2));
+}
+
+function loadGoals() {
+  return loadJson(GOALS_FILE, []);
+}
+
+function saveGoals(goals) {
+  saveJson(GOALS_FILE, goals);
+}
+
+function loadIdeas() {
+  return loadJson(IDEAS_FILE, []);
+}
+
+function saveIdeas(ideas) {
+  saveJson(IDEAS_FILE, ideas);
+}
+
+function loadState() {
+  return loadJson(STATE_FILE, {});
+}
+
+function saveState(state) {
+  saveJson(STATE_FILE, state);
+}
+
+function loadHistory() {
+  return loadJson(HISTORY_FILE, []);
+}
+
+function saveHistory(history) {
+  saveJson(HISTORY_FILE, history);
+}
+
+function generateId() {
+  return Math.random().toString(36).substring(2, 8);
+}
+
+function formatDate(isoString) {
+  const date = new Date(isoString);
+  return date.toLocaleDateString("en-US", {
+    weekday: "short",
+    month: "short",
+    day: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+  });
+}
+
+// ============================================================================
+// Orchestrator Loop
+// ============================================================================
+
+function buildClaudePrompt(goals, ideas, recentHistory) {
+  const goalsText = goals.length > 0
+    ? goals.map((g, i) => `${i + 1}. ${g.text}${g.context ? ` (Context: ${g.context})` : ""}`).join("\n")
+    : "No active goals set.";
+
+  const ideasByStatus = {
+    new: ideas.filter(i => i.status === "new"),
+    exploring: ideas.filter(i => i.status === "exploring"),
+    in_progress: ideas.filter(i => i.status === "in_progress"),
+  };
+
+  let ideasText = "";
+  if (ideasByStatus.new.length > 0) {
+    ideasText += "New ideas:\n" + ideasByStatus.new.map(i => `- ${i.text}`).join("\n") + "\n";
+  }
+  if (ideasByStatus.exploring.length > 0) {
+    ideasText += "Exploring:\n" + ideasByStatus.exploring.map(i => `- ${i.text}`).join("\n") + "\n";
+  }
+  if (ideasByStatus.in_progress.length > 0) {
+    ideasText += "In progress:\n" + ideasByStatus.in_progress.map(i => `- ${i.text}`).join("\n") + "\n";
+  }
+  if (!ideasText) {
+    ideasText = "No current ideas being tracked.";
+  }
+
+  const recentText = recentHistory.length > 0
+    ? recentHistory.slice(-5).map(h => {
+        const status = h.status === "approved" ? "✓" : "✗";
+        return `${status} ${h.action || h.text} (${h.status})`;
+      }).join("\n")
+    : "No recent activity.";
+
+  return `You are an autonomous agent helping the user achieve their goals.
+Your role is to propose concrete, actionable tasks for today based on their goals and current context.
+
+## Active Goals
+${goalsText}
+
+## Current Ideas
+${ideasText}
+
+## Recent Activity
+${recentText}
+
+Based on this context, propose 1-3 concrete actions for today.
+For each action, explain briefly why it moves toward the goal.
+You may also suggest new ideas that could help achieve the goals.
+
+IMPORTANT: Respond ONLY with valid JSON in this exact format, no other text:
+{
+  "reasoning": "brief overall reasoning for today's focus",
+  "actions": [
+    { "description": "specific action to take", "why": "how this helps the goal" }
+  ],
+  "newIdeas": [
+    { "text": "idea description", "reasoning": "why this could help" }
+  ]
+}`;
+}
+
+function parseClaudeResponse(responseText) {
+  try {
+    // Try to extract JSON from the response
+    const jsonMatch = responseText.match(/\{[\s\S]*\}/);
+    if (jsonMatch) {
+      const parsed = JSON.parse(jsonMatch[0]);
+      return {
+        reasoning: parsed.reasoning || "",
+        actions: Array.isArray(parsed.actions) ? parsed.actions : [],
+        newIdeas: Array.isArray(parsed.newIdeas) ? parsed.newIdeas : [],
+      };
+    }
+  } catch (err) {
+    console.error("[orchestrator] Failed to parse Claude response:", err.message);
+  }
+  return null;
+}
+
+function formatProposalMessage(proposal, goals) {
+  const lines = ["🎯 Daily Check-in\n"];
+
+  if (goals.length > 0) {
+    lines.push(`Goal: ${goals[0].text}\n`);
+  }
+
+  if (proposal.reasoning) {
+    lines.push(proposal.reasoning + "\n");
+  }
+
+  if (proposal.actions && proposal.actions.length > 0) {
+    lines.push("Suggested actions for today:\n");
+    proposal.actions.forEach((action, i) => {
+      lines.push(`${i + 1}. ${action.description}`);
+      if (action.why) {
+        lines.push(`   → ${action.why}`);
+      }
+    });
+    lines.push("");
+  }
+
+  if (proposal.newIdeas && proposal.newIdeas.length > 0) {
+    lines.push("New ideas generated:");
+    proposal.newIdeas.forEach(idea => {
+      lines.push(`• ${idea.text}`);
+    });
+    lines.push("");
+  }
+
+  lines.push("Reply `.approve` to proceed, or `.reject [feedback]` to decline.");
+
+  return lines.join("\n");
+}
+
+async function runCheckIn(userId, channelType, channelId) {
+  if (!_runClaude || !_channels) {
+    console.error("[orchestrator] Not initialized");
+    return null;
+  }
+
+  const channel = _channels.get(channelType);
+  if (!channel) {
+    console.error(`[orchestrator] Channel '${channelType}' not available`);
+    return null;
+  }
+
+  // Load data for this user
+  const allGoals = loadGoals();
+  const userGoals = allGoals.filter(g => g.userId === userId && g.status === "active");
+
+  if (userGoals.length === 0) {
+    await channel.send(channelId, "No active goals set. Use `.goal <text>` to add one!");
+    return null;
+  }
+
+  const allIdeas = loadIdeas();
+  const userIdeas = allIdeas.filter(i =>
+    userGoals.some(g => g.id === i.goalId) &&
+    ["new", "exploring", "in_progress"].includes(i.status)
+  );
+
+  const history = loadHistory();
+  const recentHistory = history.filter(h => h.userId === userId).slice(-10);
+
+  // Build prompt and call Claude
+  const prompt = buildClaudePrompt(userGoals, userIdeas, recentHistory);
+
+  console.log("[orchestrator] Running check-in for user:", userId);
+
+  try {
+    const response = await _runClaude(prompt);
+    const proposal = parseClaudeResponse(response.result);
+
+    if (!proposal) {
+      await channel.send(channelId, "I had trouble generating a proposal. Please try `.checkin` again.");
+      return null;
+    }
+
+    // Store any new ideas from the proposal
+    if (proposal.newIdeas && proposal.newIdeas.length > 0) {
+      const ideas = loadIdeas();
+      const primaryGoalId = userGoals[0].id;
+
+      for (const newIdea of proposal.newIdeas) {
+        ideas.push({
+          id: generateId(),
+          goalId: primaryGoalId,
+          text: newIdea.text,
+          status: "new",
+          reasoning: newIdea.reasoning || "",
+          createdAt: new Date().toISOString(),
+          updatedAt: new Date().toISOString(),
+        });
+      }
+      saveIdeas(ideas);
+    }
+
+    // Update state with pending proposal
+    const state = loadState();
+    state[userId] = {
+      lastCheckIn: new Date().toISOString(),
+      pendingProposal: {
+        actions: proposal.actions,
+        reasoning: proposal.reasoning,
+        createdAt: new Date().toISOString(),
+      },
+      awaitingApproval: true,
+      channelType,
+      channelId,
+    };
+    saveState(state);
+
+    // Register notification for pending proposal
+    if (_registerNotification) {
+      _registerNotification(`orchestrator-${userId}`, {
+        pluginName: "orchestrator",
+        label: "Pending proposal awaiting approval",
+        type: "proposal",
+        meta: { userId, actions: proposal.actions.length },
+      });
+    }
+
+    // Send formatted message to user
+    const message = formatProposalMessage(proposal, userGoals);
+    await channel.send(channelId, message);
+
+    return proposal;
+  } catch (err) {
+    console.error("[orchestrator] Check-in error:", err.message);
+    await channel.send(channelId, `Check-in error: ${err.message.slice(0, 200)}`);
+    return null;
+  }
+}
+
+async function runScheduledCheckIn() {
+  console.log("[orchestrator] Running scheduled check-in");
+
+  // Find users with active goals
+  const goals = loadGoals();
+  const activeGoals = goals.filter(g => g.status === "active");
+
+  // Group by user
+  const userGoals = new Map();
+  for (const goal of activeGoals) {
+    if (!userGoals.has(goal.userId)) {
+      userGoals.set(goal.userId, goal);
+    }
+  }
+
+  // Run check-in for each user
+  for (const [userId, goal] of userGoals) {
+    // Skip if user already has pending approval
+    const state = loadState();
+    if (state[userId]?.awaitingApproval) {
+      console.log(`[orchestrator] Skipping ${userId}: already awaiting approval`);
+      continue;
+    }
+
+    await runCheckIn(userId, goal.channelType, goal.channelId);
+  }
+}
+
+// ============================================================================
+// Commands
+// ============================================================================
+
+export default {
+  name: "orchestrator",
+
+  help: {
+    goal: "Add a new goal (e.g., .goal Build an audience around AI content)",
+    goals: "List all active goals",
+    rmgoal: "Remove/pause a goal by number or ID",
+    oidea: "Add an idea for your current goal",
+    ideas: "Show current ideas being tracked",
+    approve: "Approve pending orchestrator proposal",
+    reject: "Reject proposal with optional feedback",
+    checkin: "Trigger manual check-in now",
+    ostatus: "Show orchestrator state and next scheduled run",
+  },
+
+  commands: {
+    goal: async (msg, { reply }) => {
+      const input = msg.text.replace(/^\.goal\s*/i, "").trim();
+
+      if (!input) {
+        await reply("Usage: `.goal <text>`\nExample: `.goal Build an audience around AI content`");
+        return;
+      }
+
+      // Check for context (text after " - " or " | ")
+      let text = input;
+      let context = "";
+      const contextMatch = input.match(/^(.+?)\s*[-|]\s*(.+)$/);
+      if (contextMatch) {
+        text = contextMatch[1].trim();
+        context = contextMatch[2].trim();
+      }
+
+      const goal = {
+        id: generateId(),
+        userId: msg.userId,
+        channelType: msg.channelType,
+        channelId: msg.channelId,
+        text,
+        context,
+        status: "active",
+        createdAt: new Date().toISOString(),
+      };
+
+      const goals = loadGoals();
+      goals.push(goal);
+      saveGoals(goals);
+
+      await reply(`✅ Goal added: "${text}"\n\nUse \`.checkin\` to trigger a check-in or wait for the scheduled time.`);
+    },
+
+    goals: async (msg, { reply }) => {
+      const goals = loadGoals().filter(g => g.userId === msg.userId);
+
+      if (goals.length === 0) {
+        await reply("No goals set. Use `.goal <text>` to add one!");
+        return;
+      }
+
+      const activeGoals = goals.filter(g => g.status === "active");
+      const pausedGoals = goals.filter(g => g.status === "paused");
+
+      const lines = [];
+
+      if (activeGoals.length > 0) {
+        lines.push("🎯 Active goals:\n");
+        activeGoals.forEach((g, i) => {
+          lines.push(`${i + 1}. ${g.text}`);
+          if (g.context) lines.push(`   Context: ${g.context}`);
+          lines.push(`   Added: ${formatDate(g.createdAt)}`);
+        });
+      }
+
+      if (pausedGoals.length > 0) {
+        if (lines.length > 0) lines.push("");
+        lines.push("⏸️ Paused goals:\n");
+        pausedGoals.forEach((g, i) => {
+          lines.push(`${i + 1}. ${g.text}`);
+        });
+      }
+
+      lines.push("\nRemove with: `.rmgoal <number>`");
+
+      await reply(lines.join("\n"));
+    },
+
+    rmgoal: async (msg, { reply }) => {
+      const input = msg.text.replace(/^\.rmgoal\s*/i, "").trim();
+
+      if (!input) {
+        await reply("Usage: `.rmgoal <number or id>`\nUse `.goals` to see your goals.");
+        return;
+      }
+
+      const goals = loadGoals();
+      const userGoals = goals.filter(g => g.userId === msg.userId && g.status === "active");
+
+      let removed = null;
+      const num = parseInt(input, 10);
+
+      if (!isNaN(num) && num >= 1 && num <= userGoals.length) {
+        removed = userGoals[num - 1];
+      } else {
+        removed = userGoals.find(g => g.id === input);
+      }
+
+      if (!removed) {
+        await reply(`❌ Goal "${input}" not found. Use \`.goals\` to see your goals.`);
+        return;
+      }
+
+      // Mark as paused rather than deleting
+      const idx = goals.findIndex(g => g.id === removed.id);
+      goals[idx].status = "paused";
+      saveGoals(goals);
+
+      await reply(`✅ Paused goal: "${removed.text}"`);
+    },
+
+    oidea: async (msg, { reply }) => {
+      const input = msg.text.replace(/^\.oidea\s*/i, "").trim();
+
+      if (!input) {
+        await reply("Usage: `.oidea <text>`\nExample: `.oidea Write a Twitter thread about multi-agent systems`");
+        return;
+      }
+
+      // Find user's primary active goal
+      const goals = loadGoals().filter(g => g.userId === msg.userId && g.status === "active");
+
+      if (goals.length === 0) {
+        await reply("❌ No active goals. Add a goal first with `.goal <text>`");
+        return;
+      }
+
+      const idea = {
+        id: generateId(),
+        goalId: goals[0].id,
+        text: input,
+        status: "new",
+        reasoning: "Manually added by user",
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+      };
+
+      const ideas = loadIdeas();
+      ideas.push(idea);
+      saveIdeas(ideas);
+
+      await reply(`✅ Idea added: "${input}"`);
+    },
+
+    ideas: async (msg, { reply }) => {
+      const goals = loadGoals().filter(g => g.userId === msg.userId);
+      const goalIds = new Set(goals.map(g => g.id));
+      const ideas = loadIdeas().filter(i => goalIds.has(i.goalId));
+
+      if (ideas.length === 0) {
+        await reply("No ideas tracked yet. Add one with `.oidea <text>` or run `.checkin` to generate some!");
+        return;
+      }
+
+      const byStatus = {
+        new: ideas.filter(i => i.status === "new"),
+        exploring: ideas.filter(i => i.status === "exploring"),
+        in_progress: ideas.filter(i => i.status === "in_progress"),
+        completed: ideas.filter(i => i.status === "completed"),
+        rejected: ideas.filter(i => i.status === "rejected"),
+      };
+
+      const lines = ["💡 Your ideas:\n"];
+
+      if (byStatus.new.length > 0) {
+        lines.push("New:");
+        byStatus.new.forEach(i => lines.push(`  • ${i.text}`));
+      }
+      if (byStatus.exploring.length > 0) {
+        lines.push("Exploring:");
+        byStatus.exploring.forEach(i => lines.push(`  • ${i.text}`));
+      }
+      if (byStatus.in_progress.length > 0) {
+        lines.push("In progress:");
+        byStatus.in_progress.forEach(i => lines.push(`  • ${i.text}`));
+      }
+      if (byStatus.completed.length > 0) {
+        lines.push("Completed:");
+        byStatus.completed.slice(-3).forEach(i => lines.push(`  ✓ ${i.text}`));
+      }
+
+      await reply(lines.join("\n"));
+    },
+
+    approve: async (msg, { reply }) => {
+      const state = loadState();
+      const userState = state[msg.userId];
+
+      if (!userState?.awaitingApproval || !userState?.pendingProposal) {
+        await reply("No pending proposal to approve. Use `.checkin` to generate one.");
+        return;
+      }
+
+      const proposal = userState.pendingProposal;
+
+      // Record approval in history
+      const history = loadHistory();
+      for (const action of proposal.actions) {
+        history.push({
+          userId: msg.userId,
+          action: action.description,
+          why: action.why,
+          status: "approved",
+          approvedAt: new Date().toISOString(),
+          proposedAt: proposal.createdAt,
+        });
+      }
+      saveHistory(history);
+
+      // Update ideas that were part of the proposal to "in_progress"
+      const ideas = loadIdeas();
+      const goals = loadGoals().filter(g => g.userId === msg.userId && g.status === "active");
+      const goalIds = new Set(goals.map(g => g.id));
+
+      for (const idea of ideas) {
+        if (goalIds.has(idea.goalId) && idea.status === "new") {
+          idea.status = "exploring";
+          idea.updatedAt = new Date().toISOString();
+        }
+      }
+      saveIdeas(ideas);
+
+      // Clear pending state
+      userState.awaitingApproval = false;
+      userState.pendingProposal = null;
+      userState.lastApproval = new Date().toISOString();
+      saveState(state);
+
+      // Unregister notification
+      if (_unregisterNotification) {
+        _unregisterNotification(`orchestrator-${msg.userId}`);
+      }
+
+      const actionList = proposal.actions.map((a, i) => `${i + 1}. ${a.description}`).join("\n");
+      await reply(`✅ Approved! Here's today's focus:\n\n${actionList}\n\nGood luck! Update me on progress anytime.`);
+    },
+
+    reject: async (msg, { reply }) => {
+      const state = loadState();
+      const userState = state[msg.userId];
+
+      if (!userState?.awaitingApproval || !userState?.pendingProposal) {
+        await reply("No pending proposal to reject. Use `.checkin` to generate one.");
+        return;
+      }
+
+      const feedback = msg.text.replace(/^\.reject\s*/i, "").trim();
+      const proposal = userState.pendingProposal;
+
+      // Record rejection in history
+      const history = loadHistory();
+      history.push({
+        userId: msg.userId,
+        actions: proposal.actions,
+        status: "rejected",
+        feedback: feedback || null,
+        rejectedAt: new Date().toISOString(),
+        proposedAt: proposal.createdAt,
+      });
+      saveHistory(history);
+
+      // Clear pending state
+      userState.awaitingApproval = false;
+      userState.pendingProposal = null;
+      userState.lastRejection = new Date().toISOString();
+      userState.lastRejectionFeedback = feedback || null;
+      saveState(state);
+
+      // Unregister notification
+      if (_unregisterNotification) {
+        _unregisterNotification(`orchestrator-${msg.userId}`);
+      }
+
+      if (feedback) {
+        await reply(`📝 Got it, proposal rejected. I'll take your feedback into account:\n"${feedback}"\n\nUse \`.checkin\` when you want a new proposal.`);
+      } else {
+        await reply("📝 Got it, proposal rejected. Use `.checkin` when you want a new proposal.");
+      }
+    },
+
+    checkin: async (msg, { reply, channels, claude }) => {
+      // Store refs if not set
+      if (!_channels) _channels = channels;
+      if (!_runClaude) _runClaude = claude;
+
+      await reply("🔄 Running check-in...");
+      await runCheckIn(msg.userId, msg.channelType, msg.channelId);
+    },
+
+    ostatus: async (msg, { reply }) => {
+      const state = loadState();
+      const userState = state[msg.userId];
+      const goals = loadGoals().filter(g => g.userId === msg.userId && g.status === "active");
+      const ideas = loadIdeas().filter(i =>
+        goals.some(g => g.id === i.goalId) &&
+        ["new", "exploring", "in_progress"].includes(i.status)
+      );
+
+      const lines = ["📊 Orchestrator Status\n"];
+
+      // Goals summary
+      lines.push(`Goals: ${goals.length} active`);
+      lines.push(`Ideas: ${ideas.length} tracked`);
+
+      // Schedule info
+      lines.push(`\nSchedule: ${ORCHESTRATOR_CRON}`);
+      lines.push(`Enabled: ${ORCHESTRATOR_ENABLED ? "Yes" : "No"}`);
+
+      // Last activity
+      if (userState?.lastCheckIn) {
+        lines.push(`\nLast check-in: ${formatDate(userState.lastCheckIn)}`);
+      }
+      if (userState?.lastApproval) {
+        lines.push(`Last approval: ${formatDate(userState.lastApproval)}`);
+      }
+
+      // Pending proposal
+      if (userState?.awaitingApproval && userState?.pendingProposal) {
+        lines.push(`\n⏳ Pending proposal with ${userState.pendingProposal.actions?.length || 0} action(s)`);
+        lines.push("Reply `.approve` or `.reject [feedback]`");
+      } else {
+        lines.push("\nNo pending proposal. Use `.checkin` to generate one.");
+      }
+
+      await reply(lines.join("\n"));
+    },
+  },
+
+  schedules: ORCHESTRATOR_ENABLED ? [
+    {
+      cron: ORCHESTRATOR_CRON,
+      label: "Orchestrator daily check-in",
+      handler: runScheduledCheckIn,
+    },
+  ] : [],
+
+  init: async ({ channels, claude, registerNotification, unregisterNotification }) => {
+    _channels = channels;
+    _runClaude = claude;
+    _registerNotification = registerNotification || null;
+    _unregisterNotification = unregisterNotification || null;
+
+    // Check for any pending proposals and re-register notifications
+    const state = loadState();
+    for (const [userId, userState] of Object.entries(state)) {
+      if (userState?.awaitingApproval && _registerNotification) {
+        _registerNotification(`orchestrator-${userId}`, {
+          pluginName: "orchestrator",
+          label: "Pending proposal awaiting approval",
+          type: "proposal",
+          meta: { userId, actions: userState.pendingProposal?.actions?.length || 0 },
+        });
+      }
+    }
+
+    console.log(`[orchestrator] Initialized (schedule: ${ORCHESTRATOR_CRON}, enabled: ${ORCHESTRATOR_ENABLED})`);
+  },
+
+  destroy: () => {
+    if (_scheduledTask) {
+      _scheduledTask.stop();
+      _scheduledTask = null;
+    }
+    console.log("[orchestrator] Destroyed");
+  },
+};


### PR DESCRIPTION
## Summary
Adds a new orchestrator plugin that acts as a self-organizing agent — it tracks user goals, generates ideas via Claude, proposes daily actions, and requires human approval before proceeding.

## Key changes
- **New plugin** (`plugins/orchestrator.js`): Full orchestrator implementation with goal management, idea tracking, scheduled check-ins, and an approve/reject workflow powered by Claude
- **Commands**: `.goal`, `.goals`, `.rmgoal`, `.oidea`, `.ideas`, `.checkin`, `.approve`, `.reject`, `.ostatus`
- **Scheduled check-ins**: Configurable via `ORCHESTRATOR_CRON` (default 9am daily), can be toggled with `ORCHESTRATOR_ENABLED`
- **Documentation**: Updated README with command reference, example workflow, and config options
- **Config**: Added `ORCHESTRATOR_CRON` and `ORCHESTRATOR_ENABLED` to `.env.example`
- **Minor fix**: Updated `.gitignore` entry for `plugins/local` (removed trailing slash) and removed stale symlink

## Notes for reviewers
- The plugin uses Claude (via `runClaude`) to generate daily proposals and reflect on progress — review the prompt construction in `buildClaudePrompt()`
- State is persisted across four JSON files in `DATA_DIR`: goals, ideas, state, and history
- The approve/reject flow ensures no autonomous actions are taken without user consent