### PR TITLE
fix(admin): use PM2 stop instead of process.exit when managed

### DIFF
--- a/plugins/admin.js
+++ b/plugins/admin.js
@@ -3,7 +3,7 @@
  *
  * Provides administrative commands for managing the bot:
  *   .reload  - Hot reload all plugins without restarting
- *   .stop    - Emergency stop (kills the process immediately)
+ *   .stop    - Stop the bot (via PM2 if available, otherwise exits)
  *   .restart - Full process restart (requires PM2)
  *   .status  - Show bot status and loaded plugins
  */
@@ -16,7 +16,7 @@ export default {
 
   help: {
     reload: "Hot reload all plugins",
-    stop: "Emergency stop the bot",
+    stop: "Stop the bot (stays stopped until .restart)",
     restart: "Full process restart via PM2",
     status: "Show bot status and uptime",
   },
@@ -43,9 +43,20 @@ export default {
     },
 
     async stop(msg, { reply }) {
-      await reply("Stopping bot...");
-      await destroyPlugins();
-      process.exit(0);
+      // pm_id is always set by PM2 for managed processes
+      if (process.env.pm_id !== undefined) {
+        await reply("Stopping bot via PM2 (use .restart to bring it back)...");
+        exec("pm2 stop oyster-bot", (error) => {
+          if (error) {
+            console.error("[admin] PM2 stop failed:", error.message);
+            destroyPlugins().then(() => process.exit(0));
+          }
+        });
+      } else {
+        await reply("Stopping bot...");
+        await destroyPlugins();
+        process.exit(0);
+      }
     },
 
     async restart(msg, { reply }) {


### PR DESCRIPTION
## Summary
When the bot is running under PM2, the `.stop` command now uses `pm2 stop` instead of `process.exit(0)`, so the process stays stopped until explicitly restarted with `.restart`.

## Key changes
- Detect PM2-managed environment via `process.env.pm_id`
- Call `pm2 stop oyster-bot` when running under PM2, with fallback to `process.exit(0)` if the stop command fails
- Preserve existing `process.exit(0)` behavior when running outside PM2
- Update help text to reflect the new behavior

## Notes for reviewers
- `pm_id` is always injected by PM2 for managed processes, so it's a reliable detection method
- The fallback ensures the bot still shuts down if `pm2 stop` fails for any reason