### PR TITLE
Support Telegram media downloads with configurable limits

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,6 +8,15 @@ TELEGRAM_BOT_TOKEN=your-telegram-bot-token
 # ============================================
 # Telegram user IDs (comma-separated). Find yours via @userinfobot
 # ALLOWED_USER_IDS=123456789
+# Optional: override Telegram handler defaults
+# HANDLER_TIMEOUT_MS=300000
+# MAX_MESSAGE_LENGTH=4096
+# Directory used to store downloaded Telegram media (absolute or relative path)
+# TELEGRAM_MEDIA_DIR=./data/telegram-media
+# Maximum Telegram attachment size (in megabytes). Defaults to 15MB.
+# TELEGRAM_MEDIA_MAX_MB=15
+# Alternatively set an explicit byte size (overrides TELEGRAM_MEDIA_MAX_MB)
+# TELEGRAM_MEDIA_MAX_BYTES=15728640
 
 # ============================================
 # API KEYS

--- a/README.md
+++ b/README.md
@@ -89,6 +89,14 @@ Create a `.env` file with the following variables:
 | `HANDLER_TIMEOUT_MS` | `300000` | Telegraf handler timeout (5 min) |
 | `MAX_MESSAGE_LENGTH` | `4096` | Max chars before splitting messages |
 
+### Optional - Telegram Media
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `TELEGRAM_MEDIA_DIR` | `./data/telegram-media` | Directory where incoming Telegram files (photos/documents) are saved so Claude/Codex can read them |
+| `TELEGRAM_MEDIA_MAX_MB` | `15` | Maximum allowed attachment size in megabytes (also configurable via `TELEGRAM_MEDIA_MAX_BYTES`) |
+| `TELEGRAM_MEDIA_MAX_BYTES` | Derived from `TELEGRAM_MEDIA_MAX_MB` | Explicit byte ceiling for attachments; overrides the MB setting |
+
 ### Optional - AI Provider
 
 | Variable | Default | Description |
@@ -198,6 +206,15 @@ Bash(* --help)
 ```
 
 ## Usage
+
+### Sending Images from Telegram
+
+1. (Optional) Set `TELEGRAM_MEDIA_DIR` in `.env` if you want downloaded files to live somewhere other than `./data/telegram-media`.  
+2. Send a photo (or an image document) to your Telegram bot. Add a caption if you want the text included with the request.  
+3. Oyster bot downloads the file, stores it locally, and appends a short summary to your prompt that lists the absolute path (so Claude/Codex can `Read` it).  
+4. In your follow-up instructions you can reference the provided path directly, e.g. “Please describe the screenshot saved at `/Users/me/oyster/data/telegram-media/2025-02-09-...jpg`.”  
+
+Files larger than the configured limit (default 15 MB) are rejected and you’ll get a friendly reminder in Telegram.
 
 ### Development
 

--- a/src/channels/telegram.js
+++ b/src/channels/telegram.js
@@ -4,6 +4,9 @@
  * Implements the BaseChannel interface for Telegram using Telegraf.
  */
 
+import { randomUUID } from "crypto";
+import { mkdir, writeFile } from "fs/promises";
+import { extname, join } from "path";
 import { Telegraf } from "telegraf";
 import { BaseChannel } from "./base.js";
 import { createMessage } from "../types/message.js";
@@ -14,6 +17,8 @@ export class TelegramChannel extends BaseChannel {
     super(config);
     this.type = "telegram";
     this.bot = null;
+    this.mediaDir = config.mediaDir;
+    this.maxAttachmentBytes = config.maxAttachmentBytes;
   }
 
   /**
@@ -34,6 +39,198 @@ export class TelegramChannel extends BaseChannel {
     }
   }
 
+  async _createUnifiedMessage(ctx) {
+    const attachments = await this._collectAttachments(ctx);
+    const attachmentSummary = this._formatAttachmentSummary(attachments);
+    const baseText = ctx.message.text || ctx.message.caption || "";
+    const textParts = [];
+    if (baseText) textParts.push(baseText);
+    if (attachmentSummary) textParts.push(attachmentSummary);
+
+    return createMessage({
+      id: String(ctx.message.message_id),
+      channelType: this.type,
+      channelId: String(ctx.chat.id),
+      userId: String(ctx.from.id),
+      userName: ctx.from.first_name || ctx.from.username || "Unknown",
+      text: textParts.join("\n\n"),
+      location: ctx.message.location
+        ? {
+            latitude: ctx.message.location.latitude,
+            longitude: ctx.message.location.longitude,
+          }
+        : null,
+      attachments,
+      replyToId: ctx.message.reply_to_message
+        ? String(ctx.message.reply_to_message.message_id)
+        : null,
+      raw: ctx,
+    });
+  }
+
+  async _collectAttachments(ctx) {
+    const attachments = [];
+    if (!this.mediaDir) return attachments;
+    const chatId = String(ctx.chat.id);
+
+    const candidates = [];
+
+    if (Array.isArray(ctx.message.photo) && ctx.message.photo.length > 0) {
+      const bestSize = ctx.message.photo[ctx.message.photo.length - 1];
+      candidates.push({
+        chatId,
+        fileId: bestSize.file_id,
+        fileUniqueId: bestSize.file_unique_id,
+        type: "image",
+        subtype: "photo",
+        mimeType: "image/jpeg",
+        fileSize: bestSize.file_size,
+        metadata: {
+          width: bestSize.width,
+          height: bestSize.height,
+        },
+      });
+    }
+
+    const document = ctx.message.document;
+    if (document && document.mime_type?.startsWith("image/")) {
+      candidates.push({
+        chatId,
+        fileId: document.file_id,
+        fileUniqueId: document.file_unique_id,
+        type: "image",
+        subtype: "document",
+        mimeType: document.mime_type,
+        fileName: document.file_name,
+        fileSize: document.file_size,
+      });
+    }
+
+    for (const candidate of candidates) {
+      try {
+        const saved = await this._downloadTelegramFile(candidate);
+        if (saved) attachments.push(saved);
+      } catch (err) {
+        console.error("[telegram] Failed to download attachment:", err);
+        await this.send(
+          chatId,
+          "I couldn't download that file (possibly due to size limits). Please try again or adjust TELEGRAM_MEDIA_MAX_MB."
+        );
+      }
+    }
+
+    return attachments;
+  }
+
+  async _downloadTelegramFile({
+    chatId,
+    fileId,
+    fileUniqueId,
+    type,
+    subtype,
+    mimeType,
+    metadata = {},
+    fileName = null,
+    fileSize = null,
+  }) {
+    if (!this.bot) return null;
+    if (!this.mediaDir) return null;
+
+    const limit = this.maxAttachmentBytes;
+    if (limit && fileSize && fileSize > limit) {
+      await this.send(
+        chatId,
+        `File rejected: ${this._formatBytes(fileSize)} exceeds the configured limit of ${this._formatBytes(limit)}.`
+      );
+      return null;
+    }
+
+    const link = await this.bot.telegram.getFileLink(fileId);
+    const fileUrl = typeof link === "string" ? link : link.href || String(link);
+    const response = await fetch(fileUrl);
+    if (!response.ok) {
+      throw new Error(`Telegram file download failed with status ${response.status}`);
+    }
+
+    const resolvedMime = mimeType || response.headers.get("content-type") || "application/octet-stream";
+    const buffer = Buffer.from(await response.arrayBuffer());
+
+    if (limit && buffer.length > limit) {
+      await this.send(
+        chatId,
+        `File rejected: ${this._formatBytes(buffer.length)} exceeds the configured limit of ${this._formatBytes(limit)}.`
+      );
+      return null;
+    }
+
+    await mkdir(this.mediaDir, { recursive: true });
+    const sanitizedName = (fileName || fileUniqueId || randomUUID()).replace(/[^a-zA-Z0-9._-]/g, "_");
+    const hasExtension = Boolean(extname(sanitizedName));
+    const derivedExtension = hasExtension ? "" : this._extensionFromUrl(fileUrl) || this._extensionFromMime(resolvedMime);
+    const finalName = `${Date.now()}-${sanitizedName}${derivedExtension || ""}`;
+    const filePath = join(this.mediaDir, finalName);
+    await writeFile(filePath, buffer);
+
+    return {
+      id: fileId,
+      type,
+      subtype,
+      mimeType: resolvedMime,
+      size: buffer.length,
+      filePath,
+      originalUrl: fileUrl,
+      originalFileName: fileName,
+      metadata,
+    };
+  }
+
+  _formatAttachmentSummary(attachments) {
+    if (!attachments || attachments.length === 0) return "";
+    const lines = attachments.map((attachment, idx) => {
+      const dims =
+        attachment.metadata?.width && attachment.metadata?.height
+          ? ` ${attachment.metadata.width}x${attachment.metadata.height}px`
+          : "";
+      const sizeLabel = typeof attachment.size === "number" ? `, ${this._formatBytes(attachment.size)}` : "";
+      return `Attachment ${idx + 1}: ${attachment.subtype || attachment.type}${dims}${sizeLabel}. Saved at ${attachment.filePath}.`;
+    });
+    lines.push("Use the Read tool on the path(s) above to inspect the file contents.");
+    return lines.join("\n");
+  }
+
+  _formatBytes(bytes) {
+    if (typeof bytes !== "number" || Number.isNaN(bytes)) return "";
+    if (bytes === 0) return "0 B";
+    const units = ["B", "KB", "MB", "GB", "TB"];
+    const exponent = Math.min(
+      units.length - 1,
+      Math.floor(Math.log(bytes) / Math.log(1024))
+    );
+    const value = bytes / 1024 ** exponent;
+    return `${value.toFixed(value >= 10 || exponent === 0 ? 0 : 1)} ${units[exponent]}`;
+  }
+
+  _extensionFromMime(mimeType) {
+    if (!mimeType) return "";
+    const map = {
+      "image/jpeg": ".jpg",
+      "image/png": ".png",
+      "image/webp": ".webp",
+      "image/gif": ".gif",
+      "image/heic": ".heic",
+      "image/heif": ".heif",
+    };
+    return map[mimeType.toLowerCase()] || "";
+  }
+
+  _extensionFromUrl(url) {
+    try {
+      return extname(new URL(url).pathname);
+    } catch {
+      return "";
+    }
+  }
+
   async start() {
     this.bot = new Telegraf(this.config.botToken, {
       handlerTimeout: this.config.handlerTimeout || 300_000,
@@ -44,46 +241,17 @@ export class TelegramChannel extends BaseChannel {
       console.error(`[telegram] Error for ${ctx.updateType}:`, err.message);
     });
 
-    // Handle all text messages
-    this.bot.on("text", async (ctx) => {
+    // Handle any message type (text, captions, media, etc.)
+    this.bot.on("message", async (ctx) => {
       if (!this.onMessage) return;
-
-      const msg = createMessage({
-        id: String(ctx.message.message_id),
-        channelType: this.type,
-        channelId: String(ctx.chat.id),
-        userId: String(ctx.from.id),
-        userName: ctx.from.first_name || ctx.from.username || "Unknown",
-        text: ctx.message.text,
-        replyToId: ctx.message.reply_to_message
-          ? String(ctx.message.reply_to_message.message_id)
-          : null,
-        raw: ctx,
-      });
-
-      await this.onMessage(msg);
-    });
-
-    // Handle location messages
-    this.bot.on("location", async (ctx) => {
-      if (!this.onMessage) return;
-
-      const { latitude, longitude } = ctx.message.location;
-      const msg = createMessage({
-        id: String(ctx.message.message_id),
-        channelType: this.type,
-        channelId: String(ctx.chat.id),
-        userId: String(ctx.from.id),
-        userName: ctx.from.first_name || ctx.from.username || "Unknown",
-        text: "", // No text for location messages
-        location: { latitude, longitude },
-        replyToId: ctx.message.reply_to_message
-          ? String(ctx.message.reply_to_message.message_id)
-          : null,
-        raw: ctx,
-      });
-
-      await this.onMessage(msg);
+      try {
+        const msg = await this._createUnifiedMessage(ctx);
+        if (!msg) return;
+        await this.onMessage(msg);
+      } catch (err) {
+        console.error("[telegram] Failed to normalize message:", err);
+        await this.send(String(ctx.chat.id), "Sorry, something went wrong processing that message.");
+      }
     });
 
     await this.bot.launch({ dropPendingUpdates: true });

--- a/src/config.js
+++ b/src/config.js
@@ -1,10 +1,40 @@
 import { config as loadEnv } from "dotenv";
-import { dirname, join } from "path";
+import { homedir } from "os";
+import { dirname, join, resolve, isAbsolute } from "path";
 import { fileURLToPath } from "url";
 import { getDataDir, getPluginDirs } from "./runtime-paths.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 loadEnv({ path: join(__dirname, "..", ".env") });
+const dataDir = getDataDir();
+
+function resolveMediaDirOverride(value) {
+  if (!value) return null;
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+  if (trimmed === "~") return homedir();
+  if (trimmed.startsWith("~/")) {
+    return join(homedir(), trimmed.slice(2));
+  }
+  return isAbsolute(trimmed) ? trimmed : resolve(__dirname, "..", trimmed);
+}
+
+function resolveTelegramMediaDir() {
+  return resolveMediaDirOverride(process.env.TELEGRAM_MEDIA_DIR) || join(dataDir, "telegram-media");
+}
+
+function resolveTelegramMediaMaxBytes() {
+  const bytesEnv = Number(process.env.TELEGRAM_MEDIA_MAX_BYTES);
+  if (!Number.isNaN(bytesEnv) && bytesEnv > 0) {
+    return bytesEnv;
+  }
+  const mb = Number(process.env.TELEGRAM_MEDIA_MAX_MB);
+  const fallbackMb = !Number.isNaN(mb) && mb > 0 ? mb : 15;
+  return Math.round(fallbackMb * 1024 * 1024);
+}
+
+const telegramMediaDir = resolveTelegramMediaDir();
+const telegramMediaMaxBytes = resolveTelegramMediaMaxBytes();
 
 /**
  * Parse allowed user IDs from env (supports numbers for Telegram, strings for others)
@@ -28,6 +58,8 @@ export const config = {
       botToken: process.env.TELEGRAM_BOT_TOKEN,
       handlerTimeout: Number(process.env.HANDLER_TIMEOUT_MS) || 300_000, // 5 minutes
       maxMessageLength: Number(process.env.MAX_MESSAGE_LENGTH) || 4096,
+      mediaDir: telegramMediaDir,
+      maxAttachmentBytes: telegramMediaMaxBytes,
       // Per-channel auth (uses numeric IDs for Telegram)
       allowedUserIds: process.env.ALLOWED_USER_IDS
         ? process.env.ALLOWED_USER_IDS.split(",").map((id) => Number(id.trim()))
@@ -45,6 +77,13 @@ export const config = {
     //   appToken: process.env.SLACK_APP_TOKEN,
     //   allowedUserIds: parseAllowedUserIds(process.env.SLACK_ALLOWED_USER_IDS),
     // },
+  },
+
+  media: {
+    telegram: {
+      dir: telegramMediaDir,
+      maxAttachmentBytes: telegramMediaMaxBytes,
+    },
   },
 
   // Global settings

--- a/src/types/message.js
+++ b/src/types/message.js
@@ -28,6 +28,7 @@ export function createMessage({
   userName,
   text,
   location = null,
+  attachments = [],
   replyToId = null,
   raw = null,
 }) {
@@ -39,6 +40,7 @@ export function createMessage({
     userName,
     text,
     location,
+    attachments,
     replyToId,
     raw,
     timestamp: Date.now(),
@@ -64,6 +66,7 @@ export function getSessionKey(msg) {
  * @property {string} userName
  * @property {string} text
  * @property {Object|null} location - { latitude: number, longitude: number }
+ * @property {Array<Object>} attachments - Normalized attachment metadata (id, type, subtype, mimeType, filePath, size, metadata)
  * @property {string|null} replyToId
  * @property {Object|null} raw
  * @property {number} timestamp


### PR DESCRIPTION
Summary:
Add full Telegram media ingestion so images sent to the bot are saved locally and surfaced in prompts, along with env knobs to control storage paths and attachment limits.

Key changes:
- Extend `.env.example` and README with `TELEGRAM_MEDIA_*` options plus usage docs for sending images.
- Teach the Telegram channel to normalize all message types, download eligible photos/documents, persist them, and append attachment summaries.
- Update config loading to resolve media directories/limits and expose them via `config.media`.
- Allow message payloads (`createMessage`) to carry attachment metadata for downstream consumers.

Notes for reviewers:
- Ensure the configured `TELEGRAM_MEDIA_DIR` is readable by Claude/Codex before shipping.