### PR TITLE
docs: add troubleshooting guide for session crashes and auth errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -507,6 +507,23 @@ Sessions are maintained per chat, allowing for continuous conversations. Use `/r
 - **Budget caps**: Keep `CLAUDE_MAX_BUDGET_USD` low to prevent runaway costs
 - **Skip permissions**: Only use `CLAUDE_DANGEROUSLY_SKIP_PERMISSIONS` if you trust all whitelisted users
 
+## Troubleshooting
+
+### Claude Code session crashes or becomes unresponsive
+
+If Claude Code stops responding (e.g. the bot hangs or errors persist), `pm2 restart` won't fix it — that only restarts the bot process, not the underlying Claude Code session.
+
+**Fix:** Delete the PM2 process and recreate it:
+
+```bash
+pm2 delete oyster-bot
+pm2 start ecosystem.config.cjs
+```
+
+### Claude Pro/Max subscription expired
+
+If your Claude Pro/Max subscription has lapsed, Claude Code will fail silently or throw auth errors. Renew your subscription at [claude.ai](https://claude.ai), then start a fresh Claude Code instance (see above). A simple `pm2 restart` is not sufficient — you need to fully delete and recreate the process so Claude Code re-authenticates.
+
 ## License
 
 MIT


### PR DESCRIPTION
Adds a Troubleshooting section to the README covering two common operational issues that aren't obvious from the existing documentation.

**Key changes:**
- Documents the fix for Claude Code sessions that crash or become unresponsive (`pm2 delete` + recreate, not just `pm2 restart`)
- Explains silent auth failures when a Claude Pro/Max subscription lapses, and the required recovery steps

**Notes for reviewers:**
- These issues have caused confusion because `pm2 restart` appears to work but doesn't actually reset the underlying Claude Code session state
- The subscription expiry failure mode is particularly tricky since it fails silently — worth having this documented prominently