### PR TITLE
chore: run app via caffeinate to prevent sleep in pm2

### DIFF
--- a/ecosystem.config.cjs
+++ b/ecosystem.config.cjs
@@ -13,7 +13,8 @@
 module.exports = {
   apps: [{
     name: 'oyster-bot',
-    script: 'src/app.js',
+    script: 'caffeinate',
+    args: '-i node src/app.js',
     cwd: __dirname,               // Resolve relative paths (.env, plugins, logs) from repo root
     
     // Crash loop protection


### PR DESCRIPTION
## Summary
Wraps the pm2 process with `caffeinate -i` to prevent macOS from sleeping while the bot is running.

## Key changes
- Changed pm2 `script` from `node src/app.js` to `caffeinate` with `-i node src/app.js` as args

## Notes for reviewers
This is a macOS-specific change. `caffeinate -i` prevents system idle sleep for the duration of the process, ensuring the bot stays active when the machine would otherwise sleep.