### PR TITLE
feat: group gratitude log by date, show last 7 days

### DIFF
--- a/plugins/gratitude.js
+++ b/plugins/gratitude.js
@@ -143,9 +143,25 @@ export default {
         await reply("No gratitude entries yet. Use `.gratitude` to log one!");
         return;
       }
-      const recent = log.slice(-10);
-      const lines = recent.map((e) => `📅 ${e.date}\n🌿 ${e.text}`);
-      await reply(lines.join("\n\n"));
+
+      // Group by date
+      const byDate = {};
+      for (const e of log) {
+        if (!byDate[e.date]) byDate[e.date] = [];
+        byDate[e.date].push(e.text);
+      }
+
+      // Show last 7 days
+      const dates = Object.keys(byDate).sort().reverse().slice(0, 7);
+      const lines = [];
+      for (const date of dates) {
+        lines.push(`📅 ${date}`);
+        for (const text of byDate[date]) {
+          lines.push(`  🌿 ${text}`);
+        }
+      }
+
+      await reply(lines.join("\n"));
     },
   },
 


### PR DESCRIPTION
## Summary
Improves the gratitude log display by grouping entries under their date headers and limiting the view to the last 7 days.

## Key changes
- Groups all gratitude entries by date instead of showing a flat list
- Shows at most the last 7 days of entries (sorted newest first)
- Entries for each date are indented beneath their date header for readability
- Replaces the previous behavior of showing the last 10 individual entries regardless of date

## Notes for reviewers
The output format changes from `📅 date\n🌿 text` (one entry per block) to a grouped structure where each date appears once with its entries listed beneath it — cleaner when multiple entries exist for the same day.