### PR TITLE
fix: return "(no response)" instead of raw JSON when AI result is empty

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -196,7 +196,7 @@ async function handleAIMessage(msg, channel) {
       }
 
       const responseText =
-        result.result || result.content || JSON.stringify(result, null, 2);
+        result.result || result.content || "(no response)";
 
       const chunks = splitMessage(responseText);
       for (const chunk of chunks) {


### PR DESCRIPTION
## Summary
- When Claude returns a null/undefined result, the bot was falling back to `JSON.stringify(result)` and sending raw metadata JSON to the user
- Replaces that fallback with `"(no response)"` for a cleaner user experience

## Test plan
- [ ] Send a message that causes Claude to return an empty result; confirm you get `(no response)` instead of a JSON blob

🤖 Generated with [Claude Code](https://claude.com/claude-code)