### PR TITLE
feat: add .grateful shortcut for inline gratitude logging

### DIFF
--- a/plugins/gratitude.js
+++ b/plugins/gratitude.js
@@ -137,6 +137,17 @@ export default {
       pendingPrompts.set(msg.userId, { channelId: msg.channelId, channelType: msg.channelType, date: todayPT() });
     },
 
+    grateful: async (msg, { reply }) => {
+      const input = msg.text.replace(/^\.grateful\s*(for\s*)?/i, "").trim();
+      if (!input) {
+        await reply("Usage: `.grateful for <text>`\nExample: `.grateful for great dinner with friends`");
+        return;
+      }
+      saveEntry({ userId: msg.userId, date: todayPT(), text: input, savedAt: new Date().toISOString() });
+      const log = loadLog().filter((e) => e.userId === msg.userId);
+      await reply(`✅ Gratitude logged 🌿\n"${input}"\n${log.length} entries total.`);
+    },
+
     gratitudes: async (msg, { reply }) => {
       const log = loadLog().filter((e) => e.userId === msg.userId);
       if (log.length === 0) {


### PR DESCRIPTION
## Summary
- Adds `.grateful for <text>` as a quick inline command to log a gratitude entry without needing the prompt/reply flow
- Example: `.grateful for great dinner with friends`

## Test plan
- [ ] `.grateful for <text>` saves entry and confirms with count
- [ ] `.grateful` with no text shows usage hint
- [ ] `.gratitudes` still shows the logged entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)