### PR TITLE
fix: improve gratitude log formatting with section spacing

### DIFF
--- a/plugins/gratitude.js
+++ b/plugins/gratitude.js
@@ -164,15 +164,16 @@ export default {
 
       // Show last 7 days
       const dates = Object.keys(byDate).sort().reverse().slice(0, 7);
-      const lines = [];
+      const sections = [];
       for (const date of dates) {
-        lines.push(`📅 ${date}`);
+        const lines = [`📅 ${date}`];
         for (const text of byDate[date]) {
-          lines.push(`  🌿 ${text}`);
+          lines.push(`🌿 ${text}`);
         }
+        sections.push(lines.join("\n"));
       }
 
-      await reply(lines.join("\n"));
+      await reply(sections.join("\n\n"));
     },
   },
 


### PR DESCRIPTION
## Summary
Improves the visual formatting of the gratitude log by adding blank lines between date sections, making the output easier to read.

## Key changes
- Refactored line accumulation to group entries by date into sections
- Added double newline between date sections for visual separation
- Removed extra indentation from individual gratitude entries

## Notes for reviewers
The output structure is unchanged — same dates, same entries — but each date block is now separated by a blank line for improved readability.