### PR TITLE
fix: fall back to last emitted text when Claude result is empty

### DIFF
--- a/src/claude.js
+++ b/src/claude.js
@@ -102,6 +102,7 @@ export function runClaude(prompt, sessionId = null) {
     let stderrBuffer = "";
     let stderrRaw = "";
     let finalResult = null;
+    let lastText = null;
     let parsedSessionId = sessionId || null;
     let webSearchTimer = null;
     let settled = false;
@@ -164,6 +165,15 @@ export function runClaude(prompt, sessionId = null) {
         }
       }
 
+      // Track last text block in case final result is empty
+      if (event.type === "assistant" && event.message?.content) {
+        for (const block of event.message.content) {
+          if (block.type === "text" && block.text?.trim()) {
+            lastText = block.text.trim();
+          }
+        }
+      }
+
       // Capture the final result
       if (event.type === "result") {
         finalResult = event;
@@ -222,7 +232,7 @@ export function runClaude(prompt, sessionId = null) {
 
       if (finalResult) {
         finishResolve({
-          result: finalResult.result,
+          result: finalResult.result || lastText || null,
           session_id: extractSessionIdFromEvent(finalResult) || parsedSessionId,
           cost_usd: finalResult.cost_usd,
           duration_ms: finalResult.duration_ms,


### PR DESCRIPTION
## Summary
- When Claude's final action is a tool call (e.g. Edit) with no closing text, `result.result` is null
- This caused the bot to show a raw JSON metadata blob (old behavior) or `(no response)` (after #155)
- Now falls back to the last text block Claude emitted before the tool call, so the user sees the reasoning

## Test plan
- [ ] Ask the bot something that causes Claude to use Edit as its last action — should now show Claude's last text instead of `(no response)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)