### PR TITLE
fix: correct habit reminder cron to 7pm PT and add grid spacing

### DIFF
--- a/plugins/habit.js
+++ b/plugins/habit.js
@@ -348,7 +348,7 @@ export default {
           return `${cells}  ${habit.name}${streakStr}`;
         });
 
-        let message = "```\n" + rows.join("\n") + "\n```";
+        let message = "```\n\n" + rows.join("\n") + "\n```";
 
         await reply(message);
         return;
@@ -405,8 +405,8 @@ export default {
 
   schedules: [
     {
-      // 7pm PT = 3:00 UTC (winter, UTC-8). Override with HABIT_REMINDER_CRON.
-      cron: process.env.HABIT_REMINDER_CRON || "0 3 * * *",
+      // 7pm PT. Override with HABIT_REMINDER_CRON.
+      cron: process.env.HABIT_REMINDER_CRON || "0 19 * * *",
 
       handler: async ({ channels, config }) => {
         const targetChatId = config.plugins?.targetChatId;


### PR DESCRIPTION
Fixes the habit reminder cron schedule to use the correct 7pm PT time and adds a blank line after the opening fence in the habit grid output.

**Key changes:**
- Changed cron from `0 3 * * *` (3am UTC, hardcoded for winter only) to `0 19 * * *` (7pm PT / UTC-7 during summer, UTC-8 during winter) — the previous value was wrong outside of winter
- Added a blank line after the opening ` ``` ` in the habit grid message for better visual spacing in chat clients

**Notes for reviewers:**
- The cron `0 19 * * *` assumes the server runs in PT (UTC-7/UTC-8). If the server runs in UTC, this will need adjustment. The comment was simplified to remove the UTC offset note since it was only accurate for winter.