### PR TITLE
fix: use caffeinate -s flag to prevent system sleep

### DIFF
--- a/ecosystem.config.cjs
+++ b/ecosystem.config.cjs
@@ -14,7 +14,7 @@ module.exports = {
   apps: [{
     name: 'oyster-bot',
     script: 'caffeinate',
-    args: '-i node src/app.js',
+    args: '-s node src/app.js',
     cwd: __dirname,               // Resolve relative paths (.env, plugins, logs) from repo root
     
     // Crash loop protection


### PR DESCRIPTION
## Summary
Switches the `caffeinate` flag from `-i` (idle sleep prevention) to `-s` (system sleep prevention) to ensure the bot stays running when the system would otherwise sleep.

## Key changes
- `ecosystem.config.cjs`: Updated `caffeinate` args from `-i` to `-s`

## Notes for reviewers
`-i` only prevents idle sleep, which may not fire on all macOS power events. `-s` prevents the system from sleeping entirely while the process is running, which is the correct behavior for a persistent background bot.